### PR TITLE
Fix L4 requeuing for RAW application traffic

### DIFF
--- a/src/appl/tpg_test_raw_app.c
+++ b/src/appl/tpg_test_raw_app.c
@@ -336,13 +336,21 @@ void raw_client_data_sent(l4_control_block_t *l4, app_data_t *app_data,
         INC_STATS(raw_stats, rsts_req_cnt);
 
         if (app_data->ad_raw.ra_resp_size != 0) {
-            TEST_NOTIF(TEST_NOTIF_APP_CLIENT_SEND_STOP, l4, l4->l4cb_test_case_id,
+            TEST_NOTIF(TEST_NOTIF_APP_CLIENT_SEND_STOP, l4,
+                       l4->l4cb_test_case_id,
                        l4->l4cb_interface);
             raw_goto_state(&app_data->ad_raw, RAWS_RECEIVING,
                            app_data->ad_raw.ra_resp_size);
-        } else
+        } else {
+            TEST_NOTIF(TEST_NOTIF_APP_CLIENT_SEND_STOP, l4,
+                       l4->l4cb_test_case_id,
+                       l4->l4cb_interface);
+            TEST_NOTIF(TEST_NOTIF_APP_CLIENT_SEND_START, l4,
+                       l4->l4cb_test_case_id,
+                       l4->l4cb_interface);
             raw_goto_state(&app_data->ad_raw, RAWS_SENDING,
                            app_data->ad_raw.ra_req_size);
+        }
     }
 }
 


### PR DESCRIPTION
Issue: https://github.com/Juniper/warp17/issues/28

Send the STOP_SEND/START_SEND events when we're finished with sending a
request if expected response size is 0. This will requeue the session
allowing traffic to be sent on the others too.

Performance results:
2017-04-04 17:47:46,102 - TestPerf - INFO - Test test_1_4M_tcp_sess_setup_rate
2017-04-04 17:48:47,686 - TestPerf - INFO - Average Rate 3428780
2017-04-04 17:48:47,687 - TestPerf - INFO - Test test_2_8M_tcp_sess_setup_rate
2017-04-04 17:50:23,788 - TestPerf - INFO - Average Rate 3423014
2017-04-04 17:50:23,788 - TestPerf - INFO - Test test_3_10M_tcp_sess_setup_rate
2017-04-04 17:52:15,953 - TestPerf - INFO - Average Rate 3422505
2017-04-04 17:52:15,953 - TestPerf - INFO - Test test_4_4M_tcp_sess_data_10b_setup_rate
2017-04-04 17:53:25,484 - TestPerf - INFO - Average Rate 1823240
2017-04-04 17:53:25,485 - TestPerf - INFO - Test test_5_4M_tcp_sess_data_1024b_setup_rate
2017-04-04 17:54:35,043 - TestPerf - INFO - Average Rate 1811361
2017-04-04 17:54:35,043 - TestPerf - INFO - Test test_6_4M_tcp_sess_data_1300b_setup_rate
2017-04-04 17:55:44,645 - TestPerf - INFO - Average Rate 1956142
2017-04-04 17:55:44,645 - TestPerf - INFO - Test test_7_4M_udp_sess_data_10b_setup_rate
2017-04-04 17:56:37,854 - TestPerf - INFO - Average Rate 7444845
2017-04-04 17:56:37,854 - TestPerf - INFO - Test test_8_4M_http_sess_data_10b_setup_rate
2017-04-04 17:57:47,424 - TestPerf - INFO - Average Rate 1790170