### PR TITLE
fix code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,11 +264,9 @@ RTE_SDK. For example:
  * Install [libprotobuf-c](http://packages.ubuntu.com/trusty/amd64/libprotobuf-c0/download),
    [libprotobuf-c-dev](http://packages.ubuntu.com/trusty/amd64/libprotobuf-c0-dev/download)
    from Ubuntu 14.04LTS:
-
-		```
+		
 		sudo dpkg -i libprotobuf-c0_0.15-1build1_amd64.deb
 		sudo dpkg -i libprotobuf-c0-dev_0.15-1build1_amd64.deb
-		```
 
  * Install [libprotobuf8](http://packages.ubuntu.com/trusty/amd64/libprotobuf8/download)
    from Ubuntu 14.04LTS:

--- a/README.md
+++ b/README.md
@@ -264,24 +264,32 @@ RTE_SDK. For example:
  * Install [libprotobuf-c](http://packages.ubuntu.com/trusty/amd64/libprotobuf-c0/download),
    [libprotobuf-c-dev](http://packages.ubuntu.com/trusty/amd64/libprotobuf-c0-dev/download)
    from Ubuntu 14.04LTS:
-		
-		sudo dpkg -i libprotobuf-c0_0.15-1build1_amd64.deb
-		sudo dpkg -i libprotobuf-c0-dev_0.15-1build1_amd64.deb
+
+    ```
+    sudo dpkg -i libprotobuf-c0_0.15-1build1_amd64.deb
+    sudo dpkg -i libprotobuf-c0-dev_0.15-1build1_amd64.deb
+    ```
 
  * Install [libprotobuf8](http://packages.ubuntu.com/trusty/amd64/libprotobuf8/download)
    from Ubuntu 14.04LTS:
 
-		sudo dpkg -i libprotobuf8_2.5.0-9ubuntu1_amd64.deb
+    ```
+    sudo dpkg -i libprotobuf8_2.5.0-9ubuntu1_amd64.deb
+    ```
 
  * Install [libprotoc8](http://packages.ubuntu.com/trusty/amd64/libprotoc8/download)
    from Ubuntu 14.04LTS:
 
-		sudo dpkg -i libprotoc8_2.5.0-9ubuntu1_amd64.deb
+    ```
+    sudo dpkg -i libprotoc8_2.5.0-9ubuntu1_amd64.deb
+    ```
 
  * Install [protobuf-c-compiler](http://packages.ubuntu.com/trusty/amd64/protobuf-c-compiler/download)
    from ubuntu 14.04LTS:
 
-		sudo dpkg -i protobuf-c-compiler_0.15-1build1_amd64.deb
+    ```
+    sudo dpkg -i protobuf-c-compiler_0.15-1build1_amd64.deb
+    ```
 
 ## Get WARP17
 Get the `warp17-<ver>.tgz` archive or clone the desired


### PR DESCRIPTION
there is two ways to provide code blocks in markdown: triple back quotes or indentation, doing both will show backquotes as code