### PR TITLE
Adjust max_rx_pktlen

### DIFF
--- a/inc/tpg_port.h
+++ b/inc/tpg_port.h
@@ -231,8 +231,6 @@ extern cmdline_arg_parser_res_t port_handle_cmdline_opt(const char *opt_name,
                                                         char *opt_arg);
 extern bool                     port_handle_cmdline(void);
 
-extern void                     port_fix_pktlen(uint8_t port);
-
 /*****************************************************************************
  * Static inlines.
  ****************************************************************************/

--- a/inc/tpg_port.h
+++ b/inc/tpg_port.h
@@ -231,6 +231,8 @@ extern cmdline_arg_parser_res_t port_handle_cmdline_opt(const char *opt_name,
                                                         char *opt_arg);
 extern bool                     port_handle_cmdline(void);
 
+extern void                     port_fix_pktlen(uint8_t port);
+
 /*****************************************************************************
  * Static inlines.
  ****************************************************************************/

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -470,6 +470,8 @@ static bool port_setup_port(uint8_t port)
     struct ether_addr   mac_addr;
     tpg_port_options_t  default_port_options;
 
+    port_fix_pktlen(port);
+
     struct rte_eth_conf default_port_config = {
         .rxmode = {
             .mq_mode        = ETH_MQ_RX_RSS,
@@ -707,6 +709,20 @@ static bool port_setup_port(uint8_t port)
         return false;
 
     return true;
+}
+
+/*****************************************************************************
+ * port_fix_pktlen
+ ****************************************************************************/
+void port_fix_pktlen(uint8_t port)
+{
+    char *driver_name;
+
+    driver_name = port_dev_info[port].pi_dev_info.driver_name;
+    if (strncmp(driver_name, "net_mlx5",
+                strlen("net_mlx5") + 1) == 0) {
+        port_dev_info[port].pi_dev_info.max_rx_pktlen = 0;
+    }
 }
 
 /*****************************************************************************

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -716,7 +716,7 @@ static bool port_setup_port(uint8_t port)
  ****************************************************************************/
 void port_fix_pktlen(uint8_t port)
 {
-    char *driver_name;
+    const char *driver_name;
 
     driver_name = port_dev_info[port].pi_dev_info.driver_name;
     if (strncmp(driver_name, "net_mlx5",

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -422,9 +422,10 @@ static bool port_adjust_info(uint32_t port)
 
     /* Adjust max_rx_pktlen. Max pktlen size may be 2 * PORT_MAX_MTU.
      */
-    if (port_dev_info[port].pi_dev_info.max_rx_pktlen > 2 * PORT_MAX_MTU)
-        port_dev_info[port].pi_dev_info.max_rx_pktlen = 2 * PORT_MAX_MTU;
-    
+    if (!port_dev_info[port].pi_dev_info.max_rx_pktlen ||
+            port_dev_info[port].pi_dev_info.max_rx_pktlen > PORT_MAX_MTU)
+        port_dev_info[port].pi_dev_info.max_rx_pktlen = PORT_MAX_MTU;
+
     /* Adjust reta_size. RETA size may be 0 in case we're running on a VF.
      * e.g: for Intel 82599 10G.
      */

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -420,6 +420,11 @@ static bool port_adjust_info(uint32_t port)
 {
     struct ether_addr mac_addr;
 
+    /* Adjust max_rx_pktlen. Max pktlen size may be 2 * PORT_MAX_MTU.
+     */
+    if (port_dev_info[port].pi_dev_info.max_rx_pktlen > 2 * PORT_MAX_MTU)
+        port_dev_info[port].pi_dev_info.max_rx_pktlen = 2 * PORT_MAX_MTU;
+    
     /* Adjust reta_size. RETA size may be 0 in case we're running on a VF.
      * e.g: for Intel 82599 10G.
      */
@@ -469,8 +474,6 @@ static bool port_setup_port(uint8_t port)
     global_config_t    *cfg;
     struct ether_addr   mac_addr;
     tpg_port_options_t  default_port_options;
-
-    port_fix_pktlen(port);
 
     struct rte_eth_conf default_port_config = {
         .rxmode = {
@@ -709,20 +712,6 @@ static bool port_setup_port(uint8_t port)
         return false;
 
     return true;
-}
-
-/*****************************************************************************
- * port_fix_pktlen
- ****************************************************************************/
-void port_fix_pktlen(uint8_t port)
-{
-    const char *driver_name;
-
-    driver_name = port_dev_info[port].pi_dev_info.driver_name;
-    if (strncmp(driver_name, "net_mlx5",
-                strlen("net_mlx5") + 1) == 0) {
-        port_dev_info[port].pi_dev_info.max_rx_pktlen = 0;
-    }
 }
 
 /*****************************************************************************


### PR DESCRIPTION
In case `max_rx_pktlen` from the driver is 0 or is greater than `PORT_MAX_MTU` we force it to `PORT_MAX_MTU` (9198).

```
Perf test on vmxone:
2018-05-15 17:14:22,773 - TestPerf - INFO - Test test_01_4M_tcp_sess_setup_rate
2018-05-15 17:15:46,780 - TestPerf - INFO - Average Rate 4344939
2018-05-15 17:15:46,781 - TestPerf - INFO - Test test_02_8M_tcp_sess_setup_rate
2018-05-15 17:18:12,199 - TestPerf - INFO - Average Rate 4282897
2018-05-15 17:18:12,199 - TestPerf - INFO - Test test_03_10M_tcp_sess_setup_rate
2018-05-15 17:21:08,062 - TestPerf - INFO - Average Rate 4265508
2018-05-15 17:21:08,062 - TestPerf - INFO - Test test_04_4M_tcp_sess_data_10b_setup_rate
2018-05-15 17:22:43,643 - TestPerf - INFO - Average Rate 1848035
2018-05-15 17:22:43,643 - TestPerf - INFO - Test test_05_4M_tcp_sess_data_1024b_setup_rate
2018-05-15 17:24:19,192 - TestPerf - INFO - Average Rate 1792987
2018-05-15 17:24:19,192 - TestPerf - INFO - Test test_06_4M_tcp_sess_data_1300b_setup_rate
2018-05-15 17:25:54,724 - TestPerf - INFO - Average Rate 1943569
2018-05-15 17:25:54,725 - TestPerf - INFO - Test test_07_4M_udp_sess_data_10b_setup_rate
2018-05-15 17:27:08,534 - TestPerf - INFO - Average Rate 5755647
2018-05-15 17:27:08,534 - TestPerf - INFO - Test test_08_4M_http_sess_data_10b_setup_rate
2018-05-15 17:28:43,718 - TestPerf - INFO - Average Rate 1636644
2018-05-15 17:28:43,718 - TestPerf - INFO - Test test_09_4M_udp_mcast_flows_data_10b_setup_rate
2018-05-15 17:29:59,594 - TestPerf - INFO - Average Rate 9917375
2018-05-15 17:29:59,594 - TestPerf - INFO - Test test_10_timestamp_4M_tcp_sess_setup_rate
2018-05-15 17:31:28,410 - TestPerf - INFO - Average Rate 3822649
2018-05-15 17:31:28,410 - TestPerf - INFO - Test test_11_timestamp_4M_udp_sess_data_10b_setup_rate
2018-05-15 17:32:43,536 - TestPerf - INFO - Average Rate 5579388
2018-05-15 17:32:43,536 - TestPerf - INFO - Test test_12_recent_timestamp_4M_tcp_sess_setup_rate
2018-05-15 17:34:12,368 - TestPerf - INFO - Average Rate 3826772
2018-05-15 17:34:12,368 - TestPerf - INFO - Test test_13_recent_timestamp_4M_udp_sess_data_10b_setup_rate
2018-05-15 17:35:27,689 - TestPerf - INFO - Average Rate 5603635
2018-05-15 17:35:27,689 - TestPerf - INFO - Test test_14_timestamp_raw_4M_tcp_sess_data_1024b_setup_rate
2018-05-15 17:37:03,983 - TestPerf - INFO - Average Rate 1685792
2018-05-15 17:37:03,983 - TestPerf - INFO - Test test_15_timestamp_raw_4M_udp_sess_data_1024b_setup_rate
2018-05-15 17:38:18,706 - TestPerf - INFO - Average Rate 4482531
2018-05-15 17:38:18,706 - TestPerf - INFO - Test test_16_recent_timestamp_raw_4M_tcp_sess_data_1024b_setup_rate
2018-05-15 17:39:54,986 - TestPerf - INFO - Average Rate 1677359
2018-05-15 17:39:54,986 - TestPerf - INFO - Test test_17_recent_timestamp_raw_4M_udp_sess_data_1024b_setup_rate
2018-05-15 17:41:09,744 - TestPerf - INFO - Average Rate 4471670```