### PR TITLE
 Fix flags for hw checksum 

### DIFF
--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -535,7 +535,9 @@ static bool port_setup_port(uint8_t port)
     };
 
 #if defined(TPG_SW_CHECKSUMMING)
-    default_port_config.rxmode.hw_ip_checksum = 0;
+    if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_IPV4_CKSUM)
+        != DEV_RX_OFFLOAD_IPV4_CKSUM)
+        default_port_config.rxmode.hw_ip_checksum = 0;
 #endif /* !defined(TPG_SW_CHECKSUMMING) */
 
     /* Initialise configurations for rx and tx*/

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -497,18 +497,18 @@ static bool port_adjust_info(uint32_t port)
  ****************************************************************************/
 static bool port_setup_port(uint8_t port)
 {
-    int                 rc;
-    int                 queue;
+    int                    rc;
+    int                    queue;
 #if !defined(TPG_SW_CHECKSUMMING)
-    uint64_t            expected_rx_flags;
-    uint64_t            expected_tx_flags;
+    uint64_t               expected_rx_flags;
+    uint64_t               expected_tx_flags;
 #endif /* !defined(TPG_SW_CHECKSUMMING) */
-    uint16_t            number_of_rings;
-    global_config_t    *cfg;
-    struct ether_addr   mac_addr;
-    tpg_port_options_t  default_port_options;
-    struct rte_eth_rxconf rx_conf;
-    struct rte_eth_txconf tx_conf;
+    uint16_t               number_of_rings;
+    global_config_t       *cfg;
+    struct ether_addr      mac_addr;
+    tpg_port_options_t     default_port_options;
+    struct rte_eth_rxconf  rx_conf;
+    struct rte_eth_txconf  tx_conf;
 
     struct rte_eth_conf default_port_config = {
         .rxmode = {
@@ -533,6 +533,10 @@ static bool port_setup_port(uint8_t port)
             .mq_mode = ETH_MQ_TX_NONE,
         }
     };
+
+#if defined(TPG_SW_CHECKSUMMING)
+    default_port_config.rxmode.hw_ip_checksum = 0;
+#endif /* !defined(TPG_SW_CHECKSUMMING) */
 
     /* Initialise configurations for rx and tx*/
     port_init_rx_conf(port);

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -535,8 +535,8 @@ static bool port_setup_port(uint8_t port)
     };
 
 #if defined(TPG_SW_CHECKSUMMING)
-    if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_IPV4_CKSUM)
-        != DEV_RX_OFFLOAD_IPV4_CKSUM)
+    if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_IPV4_CKSUM) !=
+            DEV_RX_OFFLOAD_IPV4_CKSUM)
         default_port_config.rxmode.hw_ip_checksum = 0;
 #endif /* !defined(TPG_SW_CHECKSUMMING) */
 

--- a/ut/ini/jspg3.ini
+++ b/ut/ini/jspg3.ini
@@ -101,7 +101,7 @@ tcp-data-setup-rate-1024 = 2700000
 udp-data-setup-rate       = 11000000
 udp-mcast-data-setup-rate = 21000000
 
-http-data-setup-rate = 3400000
+http-data-setup-rate = 3300000
 
 timestamp-tcp-rate =  7500000
 timestamp-udp-rate = 10000000


### PR DESCRIPTION
2018-11-15 17:20:18,030 - TestPerf - INFO - Test test_01_4M_tcp_sess_setup_rate
2018-11-15 17:21:41,942 - TestPerf - INFO - Average Rate 9110042
2018-11-15 17:21:41,942 - TestPerf - INFO - Test test_02_8M_tcp_sess_setup_rate
2018-11-15 17:24:12,586 - TestPerf - INFO - Average Rate 8867311
2018-11-15 17:24:12,586 - TestPerf - INFO - Test test_03_10M_tcp_sess_setup_rate
2018-11-15 17:27:16,993 - TestPerf - INFO - Average Rate 8781586
2018-11-15 17:27:16,993 - TestPerf - INFO - Test test_04_4M_tcp_sess_data_10b_setup_rate
2018-11-15 17:28:52,593 - TestPerf - INFO - Average Rate 3750458
2018-11-15 17:28:52,593 - TestPerf - INFO - Test test_05_4M_tcp_sess_data_1024b_setup_rate
2018-11-15 17:30:28,119 - TestPerf - INFO - Average Rate 2729779
2018-11-15 17:30:28,119 - TestPerf - INFO - Test test_06_4M_tcp_sess_data_1300b_setup_rate
2018-11-15 17:32:03,736 - TestPerf - INFO - Average Rate 3698906
2018-11-15 17:32:03,736 - TestPerf - INFO - Test test_07_4M_udp_sess_data_10b_setup_rate
2018-11-15 17:33:24,620 - TestPerf - INFO - Average Rate 11529864
2018-11-15 17:33:24,620 - TestPerf - INFO - Test test_08_4M_http_sess_data_10b_setup_rate
2018-11-15 17:34:58,660 - TestPerf - INFO - Average Rate 3321408
2018-11-15 17:34:58,660 - TestPerf - INFO - Test test_09_4M_udp_mcast_flows_data_10b_setup_rate
2018-11-15 17:36:21,266 - TestPerf - INFO - Average Rate 22423733
2018-11-15 17:36:21,266 - TestPerf - INFO - Test test_10_timestamp_4M_tcp_sess_setup_rate
2018-11-15 17:37:52,894 - TestPerf - INFO - Average Rate 7839322
2018-11-15 17:37:52,894 - TestPerf - INFO - Test test_11_timestamp_4M_udp_sess_data_10b_setup_rate
2018-11-15 17:39:16,956 - TestPerf - INFO - Average Rate 10923372
2018-11-15 17:39:16,956 - TestPerf - INFO - Test test_12_recent_timestamp_4M_tcp_sess_setup_rate
2018-11-15 17:40:48,576 - TestPerf - INFO - Average Rate 7935660
2018-11-15 17:40:48,576 - TestPerf - INFO - Test test_13_recent_timestamp_4M_udp_sess_data_10b_setup_rate
2018-11-15 17:42:12,339 - TestPerf - INFO - Average Rate 10988846
2018-11-15 17:42:12,339 - TestPerf - INFO - Test test_14_timestamp_raw_4M_tcp_sess_data_1024b_setup_rate
2018-11-15 17:43:47,670 - TestPerf - INFO - Average Rate 2998002
2018-11-15 17:43:47,670 - TestPerf - INFO - Test test_15_timestamp_raw_4M_udp_sess_data_1024b_setup_rate
2018-11-15 17:45:04,200 - TestPerf - INFO - Average Rate 13388961
2018-11-15 17:45:04,201 - TestPerf - INFO - Test test_16_recent_timestamp_raw_4M_tcp_sess_data_1024b_setup_rate
2018-11-15 17:46:39,514 - TestPerf - INFO - Average Rate 2985447
2018-11-15 17:46:39,514 - TestPerf - INFO - Test test_17_recent_timestamp_raw_4M_udp_sess_data_1024b_setup_rate
2018-11-15 17:47:56,045 - TestPerf - INFO - Average Rate 13283162
