### PR TITLE
ported to DPDK 19.11.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ os: linux
 sudo: required
 compiler: gcc
 env:
-    - RTE_VERSION='17.11.6' RTE_SDK='/opt/dpdk-$(RTE_VERSION)' WARP17_INI_FILE='./ini/travis.ini'
+    - RTE_VERSION='20.05' RTE_SDK='/opt/dpdk-$(RTE_VERSION)' WARP17_INI_FILE='./ini/travis.ini'
 cache:
   directories:
     - ./build

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ os: linux
 sudo: required
 compiler: gcc
 env:
-    - RTE_VERSION='20.05' RTE_SDK='/opt/dpdk-$(RTE_VERSION)' WARP17_INI_FILE='./ini/travis.ini'
+    - RTE_VERSION='19.11.3' RTE_SDK='/opt/dpdk-$(RTE_VERSION)' WARP17_INI_FILE='./ini/travis.ini'
 cache:
   directories:
     - ./build

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ available, details can be found in the respective [documentation](ovf/README.md)
 
 ### Install DPDK
 
-Run the automated script with `<version>` as 17.11.6 (the latest LTS supported by warp17)
+Run the automated script with `<version>` as 19.11.3 (the latest LTS supported by warp17)
 
 ```
 # build_dpdk.sh -v <version>

--- a/api/warp17-stats.proto
+++ b/api/warp17-stats.proto
@@ -74,10 +74,12 @@ message PhyStatistics {
     required uint64 pys_tx_pkts     = 3;
     required uint64 pys_tx_bytes    = 4;
 
-    required uint64 pys_rx_errors   = 5;
-    required uint64 pys_tx_errors   = 6;
+    required uint64 pys_rx_drops    = 5;
+    required uint64 pys_rx_errors   = 6;
+    required uint64 pys_tx_errors   = 7;
+    required uint64 pys_rx_nombuf   = 8;
 
-    required uint32 pys_link_speed  = 7;
+    required uint32 pys_link_speed  = 9;
 }
 
 message EthStatistics {

--- a/api/warp17-stats.proto
+++ b/api/warp17-stats.proto
@@ -202,6 +202,13 @@ message TcpStatistics {
     required uint32 ts_failed_data_clone = 16;
 
     required uint32 ts_reserved_bit_set  = 17;
+
+    required uint32 ts_sent_syn = 18;
+    required uint32 ts_recv_syn = 19;
+    required uint32 ts_sent_fin = 20;
+    required uint32 ts_recv_fin = 21;
+    required uint32 ts_sent_rst = 22;
+    required uint32 ts_recv_rst = 23;
 }
 
 message TsmStatistics {

--- a/build_dpdk.sh
+++ b/build_dpdk.sh
@@ -106,7 +106,7 @@ function get {
 # $2 compiler version
 function build {
     cd $1
-    exec_cmd "Compiling dpdk for $2 arch" make T=$2 -j $3 install
+    exec_cmd "Compiling dpdk for $2 arch" make T=$2 CONFIG_RTE_EAL_IGB_UIO=y -j $3 install
 }
 
 # Install dpdk in the local machine

--- a/inc/tcp_generator.h
+++ b/inc/tcp_generator.h
@@ -67,7 +67,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <rte_ethdev.h>
+#include <rte_ethdev_driver.h>
 #include <rte_timer.h>
 #include <rte_ip.h>
 #include <rte_tcp.h>

--- a/inc/tpg_config.h
+++ b/inc/tpg_config.h
@@ -162,11 +162,11 @@ enum {
 /* TODO: No IPv6 supported. No TCP options supported.
  * Only IPv4 Tstamp Option supported.
  */
-#define GCFG_MBUF_HDR_FRAG_SIZE        (sizeof(struct ether_hdr) +     \
-                                        sizeof(struct vlan_hdr) +      \
-                                        sizeof(struct ipv4_hdr) +      \
+#define GCFG_MBUF_HDR_FRAG_SIZE        (sizeof(struct rte_ether_hdr) + \
+                                        sizeof(struct rte_vlan_hdr) +  \
+                                        sizeof(struct rte_ipv4_hdr) +  \
                                         sizeof(ipv4_tstamp_option_t) + \
-                                        sizeof(struct tcp_hdr))
+                                        sizeof(struct rte_tcp_hdr))
 #define GCFG_MBUF_HDR_SIZE             (GCFG_MBUF_HDR_FRAG_SIZE +  \
                                         sizeof(struct rte_mbuf) +  \
                                         RTE_PKTMBUF_HEADROOM)

--- a/inc/tpg_ipv4.h
+++ b/inc/tpg_ipv4.h
@@ -70,7 +70,7 @@ STATS_GLOBAL_DECLARE(tpg_ipv4_statistics_t);
  *
  ****************************************************************************/
 
-static inline uint16_t ipv4_udptcp_phdr_cksum(const struct ipv4_hdr *hdr,
+static inline uint16_t ipv4_udptcp_phdr_cksum(const struct rte_ipv4_hdr *hdr,
                                               uint16_t l4_len)
 {
     struct ipv4_psd_header {
@@ -101,7 +101,7 @@ static inline uint16_t ipv4_udptcp_phdr_cksum(const struct ipv4_hdr *hdr,
  *
  ****************************************************************************/
 static inline uint16_t ipv4_general_l4_cksum(struct rte_mbuf *mbuf,
-                                             struct ipv4_hdr *hdr,
+                                             struct rte_ipv4_hdr *hdr,
                                              uint16_t l4_offset,
                                              uint16_t l4_length)
 {
@@ -264,7 +264,7 @@ extern struct rte_mbuf *ipv4_receive_pkt(packet_control_block_t *pcb,
 extern struct rte_mbuf *ipv4_build_hdr_mbuf(l4_control_block_t *l4_cb,
                                             uint8_t protocol,
                                             uint16_t l4_len,
-                                            struct ipv4_hdr **ip_hdr_p);
+                                            struct rte_ipv4_hdr **ip_hdr_p);
 
 extern const char *ipv4_tos_to_dscp_name(const tpg_ipv4_sockopt_t *options);
 extern const char *ipv4_tos_to_ecn_name(const tpg_ipv4_sockopt_t *options);

--- a/inc/tpg_pcb.h
+++ b/inc/tpg_pcb.h
@@ -77,15 +77,15 @@ typedef struct packet_control_block_s {
     struct rte_mbuf     *pcb_mbuf;
 
     union {
-        void            *pcb_l3;
-        struct ipv4_hdr *pcb_ipv4;
-        struct arp_hdr  *pcb_arp;
+        void                *pcb_l3;
+        struct rte_ipv4_hdr *pcb_ipv4;
+        struct rte_arp_hdr  *pcb_arp;
     };
 
     union {
-        void            *pcb_l4;
-        struct tcp_hdr  *pcb_tcp;
-        struct udp_hdr  *pcb_udp;
+        void                *pcb_l4;
+        struct rte_tcp_hdr  *pcb_tcp;
+        struct rte_udp_hdr  *pcb_udp;
     };
 
     uint16_t             pcb_l4_len;

--- a/inc/tpg_port.h
+++ b/inc/tpg_port.h
@@ -185,6 +185,14 @@ typedef struct port_info_s {
     ((ls)->link_autoneg == ETH_LINK_AUTONEG ? "(auto)" :      \
         "(manual)")
 
+#define LINK_PAUSE(fc)                        \
+    ((fc)->mode == RTE_FC_NONE     ? "none" : \
+     (fc)->mode == RTE_FC_RX_PAUSE ? "rx" :   \
+     (fc)->mode == RTE_FC_TX_PAUSE ? "tx" :   \
+     (fc)->mode == RTE_FC_FULL     ? "full" : \
+                                     "???"),  \
+    ((fc)->autoneg ? "(auto)" : "(manual)")
+
 /*****************************************************************************
  * Link rate statistics
  ****************************************************************************/
@@ -216,6 +224,8 @@ extern void                     port_link_info_get(uint32_t port,
                                                    struct rte_eth_link *link_info);
 extern void                     port_link_info_get_nowait(uint32_t port,
                                                           struct rte_eth_link *link);
+extern void                     port_flow_ctrl_get(uint32_t port,
+                                                   struct rte_eth_fc_conf *fc_conf);
 extern void                     port_link_stats_get(uint32_t port,
                                                     struct rte_eth_stats *total_link_stats);
 extern void                     port_link_rate_stats_get(uint32_t port,

--- a/inc/tpg_port.h
+++ b/inc/tpg_port.h
@@ -114,9 +114,9 @@ typedef struct port_core_cfg_s {
 
 #define CORE_PORT_QINVALID (-1)
 
-#define FOREACH_PORT_IN_CORE_START(core, port)                 \
-    for ((port) = 0; (port) < rte_eth_dev_count(); (port)++) { \
-        if (port_core_cfg[core].pcc_qport_map[port] !=         \
+#define FOREACH_PORT_IN_CORE_START(core, port)                       \
+    for ((port) = 0; (port) < rte_eth_dev_count_avail(); (port)++) { \
+        if (port_core_cfg[core].pcc_qport_map[port] !=               \
                 CORE_PORT_QINVALID) {
 
 #define FOREACH_PORT_IN_CORE_END()                             \

--- a/inc/tpg_stats.h
+++ b/inc/tpg_stats.h
@@ -157,7 +157,7 @@ do {                                                \
 
 #define STATS_LOCAL_INIT(type, tag, lcore_id)                         \
     (STATS_GLOBAL_BY_CORE(type, (lcore_id)) =                         \
-        rte_zmalloc_socket(tag "_local", rte_eth_dev_count() *        \
+        rte_zmalloc_socket(tag "_local", rte_eth_dev_count_avail() *  \
                            sizeof(__typeof__(type)),                  \
                            RTE_CACHE_LINE_SIZE,                       \
                            rte_lcore_to_socket_id((lcore_id))),       \

--- a/inc/tpg_tcp.h
+++ b/inc/tpg_tcp.h
@@ -282,6 +282,7 @@ extern bool             tcp_send_ctrl_pkt(tcp_control_block_t *tcb,
 extern bool             tcp_send_ctrl_pkt_with_sseq(tcp_control_block_t *tcb,
                                                     uint32_t sseq,
                                                     uint32_t flags);
+extern bool             tcp_send_ack_pkt(tcp_control_block_t *tcb);
 extern int              tcp_open_v4_connection(tcp_control_block_t **tcb,
                                                uint32_t eth_port,
                                                uint32_t src_ip_addr,

--- a/inc/tpg_tcp.h
+++ b/inc/tpg_tcp.h
@@ -190,6 +190,8 @@ typedef struct tcp_control_block_s {
     uint32_t           tcb_retrans_cnt      :8;
     uint32_t           tcb_fin_rcvd         :1;
 
+    uint32_t           tcb_rst_rcvd         :1;
+
     /* uint32_t        tcb_unused           :17; */
 
     uint32_t           tcb_rcv_fin_seq;

--- a/inc/tpg_tcp_data.h
+++ b/inc/tpg_tcp_data.h
@@ -64,9 +64,9 @@
  * TCP MTU related macros
  ****************************************************************************/
 /* TODO: doesn't include any potential options (IP+TCP). */
-#define TCB_MIN_HDRS_SZ                                   \
-    (sizeof(struct ether_hdr) + sizeof(struct ipv4_hdr) + \
-     sizeof(struct tcp_hdr) + ETHER_CRC_LEN)
+#define TCB_MIN_HDRS_SZ                                           \
+    (sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) + \
+     sizeof(struct rte_tcp_hdr) + RTE_ETHER_CRC_LEN)
 
 /*
  * Quite an ugly hack to test that we have room to store the

--- a/inc/tpg_udp.h
+++ b/inc/tpg_udp.h
@@ -102,9 +102,9 @@ typedef struct udp_control_block_s {
  * DATA definitions
  ****************************************************************************/
 /* TODO: doesn't include any potential options (IP+TCP). */
-#define UCB_MIN_HDRS_SZ                                   \
-    (sizeof(struct ether_hdr) + sizeof(struct ipv4_hdr) + \
-     sizeof(struct udp_hdr) + ETHER_CRC_LEN)
+#define UCB_MIN_HDRS_SZ                                           \
+    (sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr) + \
+     sizeof(struct rte_udp_hdr) + RTE_ETHER_CRC_LEN)
 
 #define UDP_MTU(port_info, sockopt)                                         \
     ((port_info)->pi_mtu - ipv4_get_sockopt((sockopt))->ip4so_hdr_opt_len - \

--- a/src/appl/tpg_test_http_1_1_app.c
+++ b/src/appl/tpg_test_http_1_1_app.c
@@ -2388,7 +2388,7 @@ static void cmd_show_http_statistics_parsed(void *parsed_result __rte_unused,
     struct cmd_show_http_statistics_result *pr = parsed_result;
     int                                    option = (intptr_t) data;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 

--- a/src/kni_if/tpg_kni_if.c
+++ b/src/kni_if/tpg_kni_if.c
@@ -86,7 +86,7 @@ uint32_t kni_if_get_count(void)
  ****************************************************************************/
 uint32_t kni_get_first_kni_interface(void)
 {
-    return rte_eth_dev_count() - kni_if_get_count();
+    return rte_eth_dev_count_avail() - kni_if_get_count();
 }
 
 /*****************************************************************************
@@ -171,9 +171,10 @@ bool kni_if_init(void)
      *
      * NOTE: It's missing the ring_if_get_count() below, as it's init function
      *       has been called at this stage, so they are included in the
-     *       rte_eth_dev_count()!
+     *       rte_eth_dev_count_avail()!
      */
-    if ((rte_eth_dev_count() + kni_if_get_count()) > TPG_ETH_DEV_MAX) {
+    if ((rte_eth_dev_count_avail() + kni_if_get_count()) >
+        TPG_ETH_DEV_MAX) {
         TPG_ERROR_EXIT(EXIT_FAILURE,
                        "ERROR: Total number of virtual interfaces and ethernet ports must be less than (or equal to) %u!\n",
                        TPG_ETH_DEV_MAX);
@@ -209,7 +210,7 @@ bool kni_if_init(void)
         struct rte_kni_conf     conf;
         struct rte_kni_ops      ops;
         struct rte_eth_dev_info dev_info;
-        uint32_t                port = rte_eth_dev_count();
+        uint32_t                port = rte_eth_dev_count_avail();
 
         if (port_port_cfg[port].ppc_q_cnt != kni_cores_in_mask(port_port_cfg[port].ppc_core_mask))
             TPG_ERROR_ABORT("ERROR: Assigned lcores should be the same as number of queues!");
@@ -304,12 +305,12 @@ static int kni_change_mtu(uint16_t port, unsigned mtu)
         return -EINVAL;
     }
 
-    if (mtu < ETHER_MIN_LEN) {
+    if (mtu < RTE_ETHER_MIN_LEN) {
         RTE_LOG(ERR, USER1,
                 "ERROR: Requested MTU, %u, for port %u smaller than minimal ethernet size, %u!\n",
                 mtu,
                 port,
-                ETHER_MIN_LEN);
+                RTE_ETHER_MIN_LEN);
         return -EINVAL;
     }
 

--- a/src/ring_if/tpg_ring_if.c
+++ b/src/ring_if/tpg_ring_if.c
@@ -131,7 +131,7 @@ cmdline_arg_parser_res_t ring_if_handle_cmdline_opt(const char *opt_name, char *
 
     ring_if_pairs = val;
 
-    if (rte_eth_dev_count() + ring_if_pairs * 2 > TPG_ETH_DEV_MAX) {
+    if (rte_eth_dev_count_avail() + ring_if_pairs * 2 > TPG_ETH_DEV_MAX) {
         printf("ERROR: Total number of ring interfaces and ethernet ports must be less than\n"
                    " (or equal) %u!\n",
                TPG_ETH_DEV_MAX);
@@ -152,7 +152,7 @@ bool ring_if_init(void)
     char ring_name[TPG_RING_IF_RING_NAME_SIZE];
     char if_name[TPG_RING_IF_NAME_SIZE];
 
-    eth_dev_count = rte_eth_dev_count();
+    eth_dev_count = rte_eth_dev_count_avail();
 
     for (ring_pair_idx = 0; ring_pair_idx < ring_if_pairs; ring_pair_idx++) {
 

--- a/src/tpg_arp.c
+++ b/src/tpg_arp.c
@@ -95,7 +95,7 @@ static arp_entry_t **arp_per_port_tables;
  */
 static RTE_DEFINE_PER_LCORE(arp_entry_t **, arp_local_per_port_tables);
 
-static uint8_t arp_bcast_addr[ETHER_ADDR_LEN] = {
+static uint8_t arp_bcast_addr[RTE_ETHER_ADDR_LEN] = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 };
 
@@ -124,7 +124,7 @@ static void cmd_show_arp_entries_parsed(void *parsed_result __rte_unused,
 {
     int port;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
 
         int          entry;
         arp_entry_t *port_entries = arp_per_port_tables[port];
@@ -224,7 +224,7 @@ static void cmd_show_arp_statistics_parsed(void *parsed_result __rte_unused,
     struct cmd_show_arp_statistics_result *pr = parsed_result;
     printer_arg_t                          parg = TPG_PRINTER_ARG(cli_printer, cl);
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 
@@ -406,7 +406,8 @@ bool arp_init(void)
 
     arp_per_port_tables =
         rte_zmalloc_socket("arp_tables",
-                           rte_eth_dev_count() * sizeof(*arp_per_port_tables),
+                           rte_eth_dev_count_avail() *
+                           sizeof(*arp_per_port_tables),
                            0,
                            rte_lcore_to_socket_id(rte_lcore_id()));
     if (arp_per_port_tables == NULL) {
@@ -415,7 +416,7 @@ bool arp_init(void)
         return false;
     }
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         uint32_t port_socket;
 
         port_socket = port_dev_info[port].pi_numa_node;
@@ -444,7 +445,7 @@ void arp_lcore_init(uint32_t lcore_id)
 
     RTE_PER_LCORE(arp_local_per_port_tables) =
         rte_zmalloc_socket("arp_local_tables",
-                           rte_eth_dev_count() *
+                           rte_eth_dev_count_avail() *
                            sizeof(*RTE_PER_LCORE(arp_local_per_port_tables)),
                            RTE_CACHE_LINE_SIZE,
                            rte_lcore_to_socket_id(lcore_id));
@@ -454,7 +455,7 @@ void arp_lcore_init(uint32_t lcore_id)
                         __func__);
     }
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         RTE_PER_LCORE(arp_local_per_port_tables)[port] =
             arp_per_port_tables[port];
     }
@@ -574,11 +575,11 @@ static inline void arp_ipv4_to_uint8(uint32_t ip, uint8_t *mem)
 static bool arp_send_arp_reply(uint32_t port, uint32_t sip, uint32_t dip,
                                uint8_t *mac, uint16_t vlan_tci)
 {
-    struct rte_mbuf  *mbuf;
-    struct arp_hdr   *arp;
-    struct ether_hdr *eth;
-    struct vlan_hdr  *tag_hdr;
-    uint16_t          offset = 0;
+    struct rte_mbuf      *mbuf;
+    struct rte_arp_hdr   *arp;
+    struct rte_ether_hdr *eth;
+    struct rte_vlan_hdr  *tag_hdr;
+    uint16_t              offset = 0;
 
     /*
      * Malloc MBUF and construct the ARP packet
@@ -593,45 +594,48 @@ static bool arp_send_arp_reply(uint32_t port, uint32_t sip, uint32_t dip,
         return false;
     }
 
-    eth = rte_pktmbuf_mtod(mbuf, struct ether_hdr *);
-    offset += sizeof(struct ether_hdr);
+    eth = rte_pktmbuf_mtod(mbuf, struct rte_ether_hdr *);
+    offset += sizeof(struct rte_ether_hdr);
 
     /*
      * Here we assume mbuf segment is big enough to hold ethetnet, Vlan
      * and arp header
      */
     if (VLAN_TAG_ID(vlan_tci) == 0) {
-        mbuf->data_len = sizeof(struct ether_hdr) + sizeof(struct arp_hdr);
-        eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_ARP);
+        mbuf->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
+        eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
     } else {
         tag_hdr =
-            (struct vlan_hdr *)rte_pktmbuf_mtod_offset(mbuf, struct vlan_hdr *,
-                                                       offset);
+            (struct rte_vlan_hdr *)rte_pktmbuf_mtod_offset(mbuf,
+                                                           struct rte_vlan_hdr *,
+                                                           offset);
         tag_hdr->vlan_tci = rte_cpu_to_be_16(vlan_tci);
-        tag_hdr->eth_proto = rte_cpu_to_be_16(ETHER_TYPE_ARP);
-        mbuf->data_len = sizeof(struct ether_hdr) + sizeof(struct vlan_hdr)
-                                                  + sizeof(struct arp_hdr);
-        mbuf->l2_len = sizeof(struct ether_hdr) + sizeof(struct vlan_hdr);
-        offset += sizeof(struct vlan_hdr);
-        eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_VLAN);
+        tag_hdr->eth_proto = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
+        mbuf->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_vlan_hdr)
+                                                      + sizeof(struct rte_arp_hdr);
+        mbuf->l2_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_vlan_hdr);
+        offset += sizeof(struct rte_vlan_hdr);
+        eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN);
     }
     mbuf->pkt_len = mbuf->data_len;
 
-    arp = (struct arp_hdr *)rte_pktmbuf_mtod_offset(mbuf, struct arp_hdr *,
-                                                    offset);
+    arp = (struct rte_arp_hdr *)rte_pktmbuf_mtod_offset(mbuf,
+                                                        struct rte_arp_hdr *,
+                                                        offset);
 
-    rte_memcpy(&eth->d_addr, mac, ETHER_ADDR_LEN);
+    rte_memcpy(&eth->d_addr, mac, RTE_ETHER_ADDR_LEN);
     rte_eth_macaddr_get(port, &eth->s_addr);
 
-    arp->arp_hrd = rte_cpu_to_be_16(ARP_HRD_ETHER);
-    arp->arp_pro = rte_cpu_to_be_16(ETHER_TYPE_IPv4);
-    arp->arp_hln = ETHER_ADDR_LEN;
-    arp->arp_pln = sizeof(uint32_t);
-    arp->arp_op = rte_cpu_to_be_16(ARP_OP_REPLY);
+    arp->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HRD_ETHER);
+    arp->arp_protocol = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+    arp->arp_hlen = RTE_ETHER_ADDR_LEN;
+    arp->arp_plen = sizeof(uint32_t);
+    arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REPLY);
 
-    rte_memcpy(arp->arp_data.arp_sha.addr_bytes, &eth->s_addr, ETHER_ADDR_LEN);
+    rte_memcpy(arp->arp_data.arp_sha.addr_bytes, &eth->s_addr,
+               RTE_ETHER_ADDR_LEN);
     arp->arp_data.arp_sip = rte_cpu_to_be_32(sip);
-    rte_memcpy(arp->arp_data.arp_tha.addr_bytes, mac, ETHER_ADDR_LEN);
+    rte_memcpy(arp->arp_data.arp_tha.addr_bytes, mac, RTE_ETHER_ADDR_LEN);
     arp->arp_data.arp_tip = rte_cpu_to_be_32(dip);
 
     /*
@@ -660,11 +664,11 @@ static bool arp_send_arp_reply(uint32_t port, uint32_t sip, uint32_t dip,
 bool arp_send_arp_request(uint32_t port, uint32_t local_ip, uint32_t remote_ip,
                           uint16_t vlan_tci)
 {
-    struct rte_mbuf  *mbuf;
-    struct arp_hdr   *arp;
-    struct ether_hdr *eth;
-    struct vlan_hdr  *tag_hdr;
-    uint16_t          offset = 0;
+    struct rte_mbuf      *mbuf;
+    struct rte_arp_hdr   *arp;
+    struct rte_ether_hdr *eth;
+    struct rte_vlan_hdr  *tag_hdr;
+    uint16_t              offset = 0;
 
     /*
      * Malloc MBUF and construct the ARP packet
@@ -679,46 +683,48 @@ bool arp_send_arp_request(uint32_t port, uint32_t local_ip, uint32_t remote_ip,
         return false;
     }
 
-    eth = rte_pktmbuf_mtod(mbuf, struct ether_hdr *);
-    offset += sizeof(struct ether_hdr);
+    eth = rte_pktmbuf_mtod(mbuf, struct rte_ether_hdr *);
+    offset += sizeof(struct rte_ether_hdr);
 
     /*
      * Here we assume mbuf segment is big enough to hold ethetnet and arp header
      */
     if (VLAN_TAG_ID(vlan_tci) == 0) {
-        mbuf->data_len = sizeof(struct ether_hdr) + sizeof(struct arp_hdr);
-        eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_ARP);
+        mbuf->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_arp_hdr);
+        eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
     } else{
         tag_hdr =
-            (struct vlan_hdr *)rte_pktmbuf_mtod_offset(mbuf, struct vlan_hdr *,
-                                                       offset);
+            (struct rte_vlan_hdr *)rte_pktmbuf_mtod_offset(mbuf,
+                                                           struct rte_vlan_hdr *,
+                                                           offset);
         tag_hdr->vlan_tci = rte_cpu_to_be_16(vlan_tci);
-        tag_hdr->eth_proto = rte_cpu_to_be_16(ETHER_TYPE_ARP);
-        mbuf->data_len = sizeof(struct ether_hdr) + sizeof(struct vlan_hdr)
-                                                  + sizeof(struct arp_hdr);
-        mbuf->l2_len = sizeof(struct ether_hdr) + sizeof(struct vlan_hdr);
-        offset += sizeof(struct vlan_hdr);
-        eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_VLAN);
+        tag_hdr->eth_proto = rte_cpu_to_be_16(RTE_ETHER_TYPE_ARP);
+        mbuf->data_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_vlan_hdr)
+                                                      + sizeof(struct rte_arp_hdr);
+        mbuf->l2_len = sizeof(struct rte_ether_hdr) + sizeof(struct rte_vlan_hdr);
+        offset += sizeof(struct rte_vlan_hdr);
+        eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN);
     }
 
     mbuf->pkt_len = mbuf->data_len;
-    memset(&eth->d_addr, 0xff, ETHER_ADDR_LEN);
+    memset(&eth->d_addr, 0xff, RTE_ETHER_ADDR_LEN);
     rte_eth_macaddr_get(port, &eth->s_addr);
 
-    arp = rte_pktmbuf_mtod_offset(mbuf, struct arp_hdr *, offset);
+    arp = rte_pktmbuf_mtod_offset(mbuf, struct rte_arp_hdr *, offset);
     if (unlikely(!arp)) {
         pkt_mbuf_free(mbuf);
         return false;
     }
-    arp->arp_hrd = rte_cpu_to_be_16(ARP_HRD_ETHER);
-    arp->arp_pro = rte_cpu_to_be_16(ETHER_TYPE_IPv4);
-    arp->arp_hln = ETHER_ADDR_LEN;
-    arp->arp_pln = sizeof(uint32_t);
-    arp->arp_op = rte_cpu_to_be_16(ARP_OP_REQUEST);
+    arp->arp_hardware = rte_cpu_to_be_16(RTE_ARP_HRD_ETHER);
+    arp->arp_protocol = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+    arp->arp_hlen = RTE_ETHER_ADDR_LEN;
+    arp->arp_plen = sizeof(uint32_t);
+    arp->arp_opcode = rte_cpu_to_be_16(RTE_ARP_OP_REQUEST);
 
-    rte_memcpy(arp->arp_data.arp_sha.addr_bytes, &eth->s_addr, ETHER_ADDR_LEN);
+    rte_memcpy(arp->arp_data.arp_sha.addr_bytes, &eth->s_addr,
+               RTE_ETHER_ADDR_LEN);
     arp->arp_data.arp_sip = rte_cpu_to_be_32(local_ip);
-    bzero(arp->arp_data.arp_tha.addr_bytes, ETHER_ADDR_LEN);
+    bzero(arp->arp_data.arp_tha.addr_bytes, RTE_ETHER_ADDR_LEN);
     arp->arp_data.arp_tip = rte_cpu_to_be_32(remote_ip);
 
     /*
@@ -796,7 +802,7 @@ uint64_t arp_lookup_mac(uint32_t port, uint32_t ip, uint16_t vlan_id)
  ****************************************************************************/
 bool arp_add_local(uint32_t port, uint32_t ip, uint16_t vlan_id)
 {
-    struct ether_addr mac;
+    struct rte_ether_addr mac;
 
     rte_eth_macaddr_get(port, &mac);
 
@@ -828,10 +834,10 @@ bool arp_delete_local(uint32_t port, uint32_t ip, uint16_t vlan_id)
  ****************************************************************************/
 static void arp_process_request(packet_control_block_t *pcb, uint16_t vlan_id)
 {
-    struct arp_hdr *arp_hdr = pcb->pcb_arp;
-    uint32_t        arp_req_ip;
-    uint32_t        arp_req_sip;
-    arp_entry_t    *local_arp;
+    struct rte_arp_hdr *arp_hdr = pcb->pcb_arp;
+    uint32_t            arp_req_ip;
+    uint32_t            arp_req_sip;
+    arp_entry_t        *local_arp;
 
     /*
      * ARP ip addresses are not 32 bit alligned, so just get it this way...
@@ -873,8 +879,8 @@ static void arp_process_request(packet_control_block_t *pcb, uint16_t vlan_id)
  ****************************************************************************/
 static void arp_process_reply(packet_control_block_t *pcb, uint16_t vlan_id)
 {
-    struct arp_hdr *arp_hdr = pcb->pcb_arp;
-    uint32_t        arp_req_ip;
+    struct rte_arp_hdr *arp_hdr = pcb->pcb_arp;
+    uint32_t            arp_req_ip;
 
     /*
      * ARP ip addresses are not 32 bit alligned, so just get it this way...
@@ -904,11 +910,11 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
                                  struct rte_mbuf *mbuf,
                                  uint16_t vlan_tci)
 {
-    uint16_t        op;
-    struct arp_hdr *arp_hdr;
+    uint16_t            op;
+    struct rte_arp_hdr *arp_hdr;
 
-    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct arp_hdr))) {
-        RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for arp_hdr!\n",
+    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct rte_arp_hdr))) {
+        RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for rte_arp_hdr!\n",
                 pcb->pcb_core_index, __func__);
 
         INC_STATS(STATS_LOCAL(tpg_arp_statistics_t, pcb->pcb_port),
@@ -926,13 +932,13 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
         return mbuf;
     }
 
-    arp_hdr = rte_pktmbuf_mtod(mbuf, struct arp_hdr *);
-    op = rte_be_to_cpu_16(arp_hdr->arp_op);
+    arp_hdr = rte_pktmbuf_mtod(mbuf, struct rte_arp_hdr *);
+    op = rte_be_to_cpu_16(arp_hdr->arp_opcode);
 
     PKT_TRACE(pcb, ARP, DEBUG, "hrd=%u, pro=0x%4.4X, hln=%u, pln=%u, op=%u",
-              rte_be_to_cpu_16(arp_hdr->arp_hrd),
-              rte_be_to_cpu_16(arp_hdr->arp_pro),
-              arp_hdr->arp_hln, arp_hdr->arp_pln,
+              rte_be_to_cpu_16(arp_hdr->arp_hardware),
+              rte_be_to_cpu_16(arp_hdr->arp_protocol),
+              arp_hdr->arp_hlen, arp_hdr->arp_plen,
               op);
 
     PKT_TRACE(pcb, ARP, DEBUG, "sha=%02X:%02X:%02X:%02X:%02X:%02X spa=" TPG_IPV4_PRINT_FMT,
@@ -954,11 +960,11 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
               TPG_IPV4_PRINT_ARGS(rte_be_to_cpu_32(arp_hdr->arp_data.arp_tip)));
 
         switch (op) {
-        case ARP_OP_REQUEST:
+        case RTE_ARP_OP_REQUEST:
             INC_STATS(STATS_LOCAL(tpg_arp_statistics_t, pcb->pcb_port),
                       as_received_req);
             break;
-        case ARP_OP_REPLY:
+        case RTE_ARP_OP_REPLY:
             INC_STATS(STATS_LOCAL(tpg_arp_statistics_t, pcb->pcb_port),
                       as_received_rep);
             break;
@@ -975,7 +981,8 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
         /*
          * Check handler before we process the ARP packet
          */
-        if (unlikely(rte_be_to_cpu_16(arp_hdr->arp_hrd) != ARP_HRD_ETHER)) {
+        if (unlikely(rte_be_to_cpu_16(arp_hdr->arp_hardware) !=
+                     RTE_ARP_HRD_ETHER)) {
             RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: ARP hardware protocol is not ethernet!\n",
                     pcb->pcb_core_index, __func__);
 
@@ -984,7 +991,8 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
             return mbuf;
         }
 
-        if (unlikely(rte_be_to_cpu_16(arp_hdr->arp_pro) != ETHER_TYPE_IPv4)) {
+        if (unlikely(rte_be_to_cpu_16(arp_hdr->arp_protocol) !=
+                     RTE_ETHER_TYPE_IPV4)) {
             RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: Protocol is not IPv4!\n",
                     pcb->pcb_core_index, __func__);
 
@@ -993,7 +1001,7 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
             return mbuf;
         }
 
-        if (unlikely(arp_hdr->arp_hln != ETHER_ADDR_LEN)) {
+        if (unlikely(arp_hdr->arp_hlen != RTE_ETHER_ADDR_LEN)) {
             RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: Hardware length is not 6!\n",
                     pcb->pcb_core_index, __func__);
 
@@ -1002,7 +1010,7 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
             return mbuf;
         }
 
-        if (unlikely(arp_hdr->arp_pln != sizeof(uint32_t))) {
+        if (unlikely(arp_hdr->arp_plen != sizeof(uint32_t))) {
             RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: Protocol length is not 4!\n",
                     pcb->pcb_core_index, __func__);
 
@@ -1014,9 +1022,9 @@ struct rte_mbuf *arp_receive_pkt(packet_control_block_t *pcb,
 
         pcb->pcb_arp = arp_hdr;
 
-        if (op == ARP_OP_REQUEST)
+        if (op == RTE_ARP_OP_REQUEST)
             arp_process_request(pcb, VLAN_TAG_ID(vlan_tci));
-        else if (op == ARP_OP_REPLY)
+        else if (op == RTE_ARP_OP_REPLY)
             arp_process_reply(pcb, VLAN_TAG_ID(vlan_tci));
 
         return mbuf;

--- a/src/tpg_ethernet.c
+++ b/src/tpg_ethernet.c
@@ -103,7 +103,7 @@ static void cmd_show_ethernet_statistics_parsed(void *parsed_result __rte_unused
     printer_arg_t                               parg = TPG_PRINTER_ARG(cli_printer, cl);
     struct cmd_show_ethernet_statistics_result *pr = parsed_result;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 
@@ -269,9 +269,9 @@ struct rte_mbuf *eth_build_hdr_mbuf(l4_control_block_t *l4_cb,
                                     uint64_t src_mac,
                                     uint16_t ether_type)
 {
-    struct ether_hdr *eth;
-    struct rte_mbuf  *mbuf;
-    struct vlan_hdr *tag_hdr;
+    struct rte_ether_hdr *eth;
+    struct rte_mbuf      *mbuf;
+    struct rte_vlan_hdr  *tag_hdr;
     uint32_t port = l4_cb->l4cb_interface;
 
     mbuf = pkt_mbuf_alloc(mem_get_mbuf_local_pool_tx_hdr());
@@ -292,8 +292,8 @@ struct rte_mbuf *eth_build_hdr_mbuf(l4_control_block_t *l4_cb,
     /*
      * Build ethernet header
      */
-    eth = (struct ether_hdr *) rte_pktmbuf_append(mbuf,
-                                                  sizeof(struct ether_hdr));
+    eth = (struct rte_ether_hdr *)
+        rte_pktmbuf_append(mbuf, sizeof(struct rte_ether_hdr));
 
     if (unlikely(!eth)) {
         pkt_mbuf_free(mbuf);
@@ -307,11 +307,11 @@ struct rte_mbuf *eth_build_hdr_mbuf(l4_control_block_t *l4_cb,
      * Build the Vlan header if vlan is configured by user
      */
     if (l4_cb->l4cb_sockopt.so_vlan.vlanso_hdr_opt_len > 0) {
-        eth->ether_type = rte_cpu_to_be_16(ETHER_TYPE_VLAN);
+        eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN);
 
         tag_hdr =
-            (struct vlan_hdr *)rte_pktmbuf_append(mbuf,
-                                                  sizeof(struct vlan_hdr));
+            (struct rte_vlan_hdr *)rte_pktmbuf_append(mbuf,
+                                                      sizeof(struct rte_vlan_hdr));
 
         if (unlikely(!tag_hdr)) {
             pkt_mbuf_free(mbuf);
@@ -332,7 +332,7 @@ struct rte_mbuf *eth_build_hdr_mbuf(l4_control_block_t *l4_cb,
          * We assume hardware checksum calculation for ip/tcp, to
          * support this we need to set the correct l2 header size.
          */
-        mbuf->l2_len = sizeof(struct ether_hdr) +
+        mbuf->l2_len = sizeof(struct rte_ether_hdr) +
                            l4_cb->l4cb_sockopt.so_vlan.vlanso_hdr_opt_len;
     }
 
@@ -348,12 +348,12 @@ struct rte_mbuf *eth_build_hdr_mbuf(l4_control_block_t *l4_cb,
 struct rte_mbuf *eth_receive_pkt(packet_control_block_t *pcb,
                                  struct rte_mbuf *mbuf)
 {
-    uint16_t          etype;
-    struct ether_hdr *eth_hdr;
-    uint16_t          vlan_tci  = VLAN_NO_TAG;
+    uint16_t              etype;
+    struct rte_ether_hdr *eth_hdr;
+    uint16_t              vlan_tci  = VLAN_NO_TAG;
 
-    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct ether_hdr))) {
-        RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for ether_hdr!\n",
+    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct rte_ether_hdr))) {
+        RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for rte_ether_hdr!\n",
                 pcb->pcb_core_index, __func__);
 
         INC_STATS(STATS_LOCAL(tpg_eth_statistics_t, pcb->pcb_port),
@@ -361,7 +361,7 @@ struct rte_mbuf *eth_receive_pkt(packet_control_block_t *pcb,
         return mbuf;
     }
 
-    eth_hdr = rte_pktmbuf_mtod(mbuf, struct ether_hdr *);
+    eth_hdr = rte_pktmbuf_mtod(mbuf, struct rte_ether_hdr *);
     etype = rte_be_to_cpu_16(eth_hdr->ether_type);
 
     PKT_TRACE(pcb, ETH, DEBUG, "dst=%02X:%02X:%02X:%02X:%02X:%02X, src=%02X:%02X:%02X:%02X:%02X:%02X, etype=0x%4.4X",
@@ -383,21 +383,21 @@ struct rte_mbuf *eth_receive_pkt(packet_control_block_t *pcb,
      * Pop all vlan tags to determine protocol type.
      * TODO: we only pass on the inner-most vlan tag right now.
      */
-    if (unlikely(etype == ETHER_TYPE_VLAN)) {
+    if (unlikely(etype == RTE_ETHER_TYPE_VLAN)) {
 
         INC_STATS(STATS_LOCAL(tpg_eth_statistics_t, pcb->pcb_port),
                   es_etype_vlan);
 
         assert(pcb->pcb_mbuf == mbuf);
-        mbuf = data_adj_chain(mbuf, sizeof(struct ether_hdr));
+        mbuf = data_adj_chain(mbuf, sizeof(struct rte_ether_hdr));
         pcb->pcb_mbuf = mbuf;
 
         do {
-            struct vlan_hdr *tag_hdr;
+            struct rte_vlan_hdr *tag_hdr;
 
-            tag_hdr = rte_pktmbuf_mtod(mbuf, struct vlan_hdr *);
+            tag_hdr = rte_pktmbuf_mtod(mbuf, struct rte_vlan_hdr *);
 
-            if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct vlan_hdr))) {
+            if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct rte_vlan_hdr))) {
                 RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for vlan_hdr!\n",
                         pcb->pcb_core_index, __func__);
 
@@ -413,14 +413,14 @@ struct rte_mbuf *eth_receive_pkt(packet_control_block_t *pcb,
                       vlan_tci, etype);
 
             assert(pcb->pcb_mbuf == mbuf);
-            mbuf = data_adj_chain(mbuf, sizeof(struct vlan_hdr));
+            mbuf = data_adj_chain(mbuf, sizeof(struct rte_vlan_hdr));
             pcb->pcb_mbuf = mbuf;
 
-        } while (etype == ETHER_TYPE_VLAN);
+        } while (etype == RTE_ETHER_TYPE_VLAN);
 
     } else {
         assert(pcb->pcb_mbuf == mbuf);
-        mbuf = data_adj_chain(mbuf, sizeof(struct ether_hdr));
+        mbuf = data_adj_chain(mbuf, sizeof(struct rte_ether_hdr));
         pcb->pcb_mbuf = mbuf;
     }
 
@@ -431,19 +431,19 @@ struct rte_mbuf *eth_receive_pkt(packet_control_block_t *pcb,
      */
     switch (etype) {
 
-    case ETHER_TYPE_IPv4:
+    case RTE_ETHER_TYPE_IPV4:
         INC_STATS(STATS_LOCAL(tpg_eth_statistics_t, pcb->pcb_port),
                   es_etype_ipv4);
         mbuf = ipv4_receive_pkt(pcb, mbuf);
         break;
 
-    case ETHER_TYPE_ARP:
+    case RTE_ETHER_TYPE_ARP:
         INC_STATS(STATS_LOCAL(tpg_eth_statistics_t, pcb->pcb_port),
                   es_etype_arp);
         mbuf = arp_receive_pkt(pcb, mbuf, vlan_tci);
         break;
 
-    case ETHER_TYPE_IPv6:
+    case RTE_ETHER_TYPE_IPV6:
         /* TODO: handle IPv6 */
         INC_STATS(STATS_LOCAL(tpg_eth_statistics_t, pcb->pcb_port),
                   es_etype_ipv6);
@@ -468,7 +468,7 @@ void vlan_store_sockopt(vlan_sockopt_t *dest, const tpg_vlan_sockopt_t *options)
 
     /* Set the header length based on vlan option provided or not*/
     if (dest->vlanso_id)
-        dest->vlanso_hdr_opt_len = sizeof(struct vlan_hdr);
+        dest->vlanso_hdr_opt_len = sizeof(struct rte_vlan_hdr);
     else
         dest->vlanso_hdr_opt_len = 0;
 }

--- a/src/tpg_ipv4.c
+++ b/src/tpg_ipv4.c
@@ -191,7 +191,7 @@ static void cmd_show_ipv4_statistics_parsed(void *parsed_result __rte_unused,
     int                                     option = (intptr_t) data;
     struct cmd_show_ipv4_statistics_result *pr = parsed_result;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 
@@ -513,20 +513,20 @@ uint8_t ipv4_dscp_ecn_to_tos(const char *dscp_str, const char *ecn_str)
 /*****************************************************************************
  * ipv4_build_hdr()
  ****************************************************************************/
-static struct ipv4_hdr *ipv4_build_hdr(l4_control_block_t *l4_cb,
-                                       struct rte_mbuf *mbuf,
-                                       uint8_t protocol,
-                                       uint16_t l4_len,
-                                       struct ipv4_hdr *ref_ip_hdr)
+static struct rte_ipv4_hdr *ipv4_build_hdr(l4_control_block_t *l4_cb,
+                                           struct rte_mbuf *mbuf,
+                                           uint8_t protocol,
+                                           uint16_t l4_len,
+                                           struct rte_ipv4_hdr *ref_ip_hdr)
 {
-    struct ipv4_hdr *ip_hdr;
-    uint16_t         ip_hdr_len = sizeof(struct ipv4_hdr);
+    struct rte_ipv4_hdr *ip_hdr;
+    uint16_t         ip_hdr_len = sizeof(struct rte_ipv4_hdr);
     sockopt_t       *sockopt = &l4_cb->l4cb_sockopt;
 
     if (unlikely(ref_ip_hdr != NULL))
         TPG_ERROR_ABORT("TODO: No reference IPv4 header supported!\n");
 
-    ip_hdr = (struct ipv4_hdr *) rte_pktmbuf_append(mbuf, ip_hdr_len);
+    ip_hdr = (struct rte_ipv4_hdr *) rte_pktmbuf_append(mbuf, ip_hdr_len);
     if (unlikely(!ip_hdr))
         return NULL;
 
@@ -595,7 +595,7 @@ static struct ipv4_hdr *ipv4_build_hdr(l4_control_block_t *l4_cb,
 struct rte_mbuf *ipv4_build_hdr_mbuf(l4_control_block_t *l4_cb,
                                      uint8_t protocol,
                                      uint16_t l4_len,
-                                     struct ipv4_hdr **ip_hdr_p)
+                                     struct rte_ipv4_hdr **ip_hdr_p)
 {
     struct rte_mbuf *mbuf;
     port_info_t     *port_info;
@@ -627,7 +627,7 @@ struct rte_mbuf *ipv4_build_hdr_mbuf(l4_control_block_t *l4_cb,
         return NULL;
     }
 
-    mbuf = eth_build_hdr_mbuf(l4_cb, dst_mac, src_mac, ETHER_TYPE_IPv4);
+    mbuf = eth_build_hdr_mbuf(l4_cb, dst_mac, src_mac, RTE_ETHER_TYPE_IPV4);
     if (unlikely(!mbuf))
         return NULL;
 
@@ -651,21 +651,21 @@ struct rte_mbuf *ipv4_receive_pkt(packet_control_block_t *pcb,
 {
     unsigned int           ip_hdr_len;
     tpg_ipv4_statistics_t *stats;
-    struct ipv4_hdr       *ip_hdr;
+    struct rte_ipv4_hdr   *ip_hdr;
     uint64_t               ipv4_tstamp_value;
 
     ipv4_tstamp_value = 0;
 
     stats = STATS_LOCAL(tpg_ipv4_statistics_t, pcb->pcb_port);
 
-    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct ipv4_hdr))) {
+    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct rte_ipv4_hdr))) {
         RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for ipv4_hdr!\n",
                 pcb->pcb_core_index, __func__);
         INC_STATS(stats, ips_to_small_fragment);
         return mbuf;
     }
 
-    ip_hdr = rte_pktmbuf_mtod(mbuf, struct ipv4_hdr *);
+    ip_hdr = rte_pktmbuf_mtod(mbuf, struct rte_ipv4_hdr *);
     ip_hdr_len = (ip_hdr->version_ihl & 0x0F) << 2;
 
     PKT_TRACE(pcb, IPV4, DEBUG, "src/dst=%8.8X/%8.8X, prot=%u, hdrlen=%d, len=%u",
@@ -678,18 +678,18 @@ struct rte_mbuf *ipv4_receive_pkt(packet_control_block_t *pcb,
     PKT_TRACE(pcb, IPV4, DEBUG, " ttl=%u, tos=%u, frag=0x%4.4X[%c%c%c], id=0x%4.4X, csum=0x%4.4X",
               ip_hdr->time_to_live,
               ip_hdr->type_of_service,
-              rte_be_to_cpu_16(ip_hdr->fragment_offset) & IPV4_HDR_OFFSET_MASK,
+              rte_be_to_cpu_16(ip_hdr->fragment_offset) & RTE_IPV4_HDR_OFFSET_MASK,
               (rte_be_to_cpu_16(ip_hdr->fragment_offset) & 1<<15) == 0 ? '-' : 'R',
-              (rte_be_to_cpu_16(ip_hdr->fragment_offset) & IPV4_HDR_DF_FLAG) == 0 ? '-' : 'd',
-              (rte_be_to_cpu_16(ip_hdr->fragment_offset) & IPV4_HDR_MF_FLAG) == 0 ? '-' : 'm',
+              (rte_be_to_cpu_16(ip_hdr->fragment_offset) & RTE_IPV4_HDR_DF_FLAG) == 0 ? '-' : 'd',
+              (rte_be_to_cpu_16(ip_hdr->fragment_offset) & RTE_IPV4_HDR_MF_FLAG) == 0 ? '-' : 'm',
               rte_be_to_cpu_16(ip_hdr->packet_id),
               rte_be_to_cpu_16(ip_hdr->hdr_checksum));
 
     /*
      * TODO: We don't support IP fragments yet so inc counter and drop.
      */
-    if (unlikely((rte_be_to_cpu_16(ip_hdr->fragment_offset) & IPV4_HDR_MF_FLAG) ||
-                 (rte_be_to_cpu_16(ip_hdr->fragment_offset) & IPV4_HDR_OFFSET_MASK))) {
+    if (unlikely((rte_be_to_cpu_16(ip_hdr->fragment_offset) & RTE_IPV4_HDR_MF_FLAG) ||
+                 (rte_be_to_cpu_16(ip_hdr->fragment_offset) & RTE_IPV4_HDR_OFFSET_MASK))) {
         INC_STATS(stats, ips_received_frags);
         return mbuf;
     }
@@ -729,7 +729,7 @@ struct rte_mbuf *ipv4_receive_pkt(packet_control_block_t *pcb,
         return mbuf;
     }
 
-    if (unlikely(ip_hdr_len < sizeof(struct ipv4_hdr))) {
+    if (unlikely(ip_hdr_len < sizeof(struct rte_ipv4_hdr))) {
         RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: IP hdr len smaller than header!\n",
                 pcb->pcb_core_index, __func__);
 
@@ -765,7 +765,7 @@ struct rte_mbuf *ipv4_receive_pkt(packet_control_block_t *pcb,
 
 #endif
 
-    if (unlikely(ip_hdr_len > sizeof(struct ipv4_hdr))) {
+    if (unlikely(ip_hdr_len > sizeof(struct rte_ipv4_hdr))) {
         if (ipv4_parse_options(mbuf, ip_hdr_len, stats, &ipv4_tstamp_value,
                                pcb))
             return mbuf;
@@ -847,7 +847,7 @@ static int ipv4_parse_options(struct rte_mbuf *mbuf, uint32_t total_len,
     uint32_t           std_ipv4_hdr_len;
     ipv4_option_hdr_t *ip_opt_hdr;
 
-    std_ipv4_hdr_len = sizeof(struct ipv4_hdr);
+    std_ipv4_hdr_len = sizeof(struct rte_ipv4_hdr);
     offset = std_ipv4_hdr_len;     /* already processed options length */
     total_len -= std_ipv4_hdr_len; /* remaining options length to process */
 

--- a/src/tpg_lookup.c
+++ b/src/tpg_lookup.c
@@ -127,10 +127,10 @@ bool tlkp_init(void)
          * See https://msdn.microsoft.com/en-us/library/windows/hardware/ff571021(v=vs.85).aspx
          * for hash examples, we picket the first one.
          */
-        uint32_t src_addr = IPv4(66, 9, 149, 187);
+        uint32_t src_addr = RTE_IPV4(66, 9, 149, 187);
         uint16_t src_port = 2794;
 
-        uint32_t dst_addr = IPv4(161, 142, 100, 80);
+        uint32_t dst_addr = RTE_IPV4(161, 142, 100, 80);
         uint16_t dst_port = 1766;
 
         uint32_t thash = tlkp_calc_connection_hash(src_addr, dst_addr,

--- a/src/tpg_main.c
+++ b/src/tpg_main.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
                        "ERROR: WARP17 supports at most %"PRIu32" cores!\n",
                        (uint32_t)sizeof(uint64_t) * 8);
     }
-    if (rte_eth_dev_count() > TPG_ETH_DEV_MAX) {
+    if (rte_eth_dev_count_avail() > TPG_ETH_DEV_MAX) {
         TPG_ERROR_EXIT(EXIT_FAILURE,
                        "ERROR: WARP17 works with at most %u ports!\n",
                        TPG_ETH_DEV_MAX);
@@ -205,8 +205,8 @@ int main(int argc, char **argv)
 
     /* WARNING: Careful when adding code above this point. Up until ports are
      * initialized DPDK can't know that there might be ring interfaces that
-     * still need to be created. Therefore any call to rte_eth_dev_count()
-     * doesn't include them.
+     * still need to be created. Therefore any call to
+     * rte_eth_dev_count_avail() doesn't include them.
      */
     if (!port_init()) {
         TPG_ERROR_EXIT(EXIT_FAILURE, "ERROR: %s!\n",

--- a/src/tpg_pktloop.c
+++ b/src/tpg_pktloop.c
@@ -195,7 +195,7 @@ static void pkt_trace_tx(packet_control_block_t *pcb, int32_t tx_queue_id,
                               (tcp_hdr->tcp_flags & RTE_TCP_PSH_FLAG) == 0 ? '-' : 'p',
                               (tcp_hdr->tcp_flags & RTE_TCP_RST_FLAG) == 0 ? '-' : 'r',
                               (tcp_hdr->tcp_flags & RTE_TCP_SYN_FLAG) == 0 ? '-' : 's',
-                              (tcp_hdr->tcp_flags & TCP_FIN_FLAG) == 0 ? '-' : 'f',
+                              (tcp_hdr->tcp_flags & RTE_TCP_FIN_FLAG) == 0 ? '-' : 'f',
                               rte_be_to_cpu_16(tcp_hdr->cksum));
 
                     PKT_TRACE(pcb, TCP, DEBUG, " seq=%u, ack=%u, window=%u, urgent=%u",

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -1060,6 +1060,14 @@ void port_link_info_get_nowait(uint32_t port, struct rte_eth_link *link)
 }
 
 /*****************************************************************************
+ * port_flow_ctrl_get()
+ *****************************************************************************/
+void port_flow_ctrl_get(uint32_t port, struct rte_eth_fc_conf *fc_conf)
+{
+    rte_eth_dev_flow_ctrl_get(port, fc_conf);
+}
+
+/*****************************************************************************
  * port_link_stats_get()
  *****************************************************************************/
 void port_link_stats_get(uint32_t port, struct rte_eth_stats *total_link_stats)
@@ -1098,6 +1106,9 @@ void port_link_rate_stats_get(uint32_t port, struct rte_eth_stats *total_rstats)
 
     total_rstats->obytes = (estats.obytes - lrstats->lrs_estats.obytes) *
                            hz / time_diff;
+
+    total_rstats->imissed = (estats.imissed - lrstats->lrs_estats.imissed) *
+                            hz / time_diff;
 
     total_rstats->ierrors = (estats.ierrors - lrstats->lrs_estats.ierrors) *
                             hz / time_diff;
@@ -1498,22 +1509,24 @@ static void cmd_show_port_link_parsed(void *parsed_result __rte_unused,
 
     for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         struct rte_eth_link link;
+        struct rte_eth_fc_conf fc_conf;
 
         port_link_info_get(port, &link);
+        port_flow_ctrl_get(port, &fc_conf);
 
         if (link.link_status == 0) {
             cmdline_printf(cl, "Port %d linkstate %s\n",
                            port, "DOWN");
         } else {
-
             cmdline_printf(cl,
                            "Port %"PRIu32" linkstate %s, speed %d%s, "
-                           "duplex %s%s\n",
+                           "duplex %s%s, pause %s%s\n",
                            port,
                            LINK_STATE(&link),
                            LINK_SPEED(&link),
                            LINK_SPEED_SZ(&link),
-                           LINK_DUPLEX(&link));
+                           LINK_DUPLEX(&link),
+                           LINK_PAUSE(&fc_conf));
         }
     }
 }

--- a/src/tpg_port.c
+++ b/src/tpg_port.c
@@ -168,25 +168,9 @@ static void port_setup_reta_table(uint8_t port, int nr_of_queus)
 /*****************************************************************************
  * port_init_tx_conf()
  ****************************************************************************/
-static void port_init_tx_conf(uint16_t port)
+static void port_init_tx_conf(uint16_t port __rte_unused)
 {
-#if !defined(TPG_SW_CHECKSUMMING)
-    struct rte_eth_txconf *tx_conf;
 
-    /* We need to enable UDP/TCP hw checksum because software checksum would
-     * take too many cpu cycles, SCTP checksum offload is not supported!
-     */
-    tx_conf = &port_dev_info[port].pi_dev_info.default_txconf;
-
-    if ((tx_conf->txq_flags & ETH_TXQ_FLAGS_NOXSUMUDP) ==
-        ETH_TXQ_FLAGS_NOXSUMUDP)
-        tx_conf->txq_flags &= ~ETH_TXQ_FLAGS_NOXSUMUDP;
-    if ((tx_conf->txq_flags & ETH_TXQ_FLAGS_NOXSUMTCP) ==
-        ETH_TXQ_FLAGS_NOXSUMTCP)
-        tx_conf->txq_flags &= ~ETH_TXQ_FLAGS_NOXSUMTCP;
-#else /* !defined(TPG_SW_CHECKSUMMING) */
-    RTE_SET_USED(port);
-#endif /* !defined(TPG_SW_CHECKSUMMING) */
 }
 
 /*****************************************************************************
@@ -207,7 +191,7 @@ static inline uint32_t port_get_pre_init_port_count(void)
      * This gets the total number of potential ports in the system,
      * total physical ports, plus potential virtual ports.
      */
-    return rte_eth_dev_count() + ring_if_get_count() + kni_if_get_count();
+    return rte_eth_dev_count_avail() + ring_if_get_count() + kni_if_get_count();
 }
 
 /*****************************************************************************
@@ -223,8 +207,9 @@ static inline bool port_is_kni_port(uint32_t port)
  ****************************************************************************/
 static inline bool port_pre_init_is_kni_port(uint32_t port)
 {
-    if (port >= (rte_eth_dev_count() + ring_if_get_count()) &&
-        port < (rte_eth_dev_count() + ring_if_get_count() + kni_if_get_count()))
+    if (port >= (rte_eth_dev_count_avail() + ring_if_get_count()) &&
+        port < (rte_eth_dev_count_avail() + ring_if_get_count() +
+                kni_if_get_count()))
         return true;
 
     return false;
@@ -250,8 +235,8 @@ static bool port_pre_init_all_kni_ports(void)
  ****************************************************************************/
 static bool port_pre_init_is_ring_port(uint32_t port)
 {
-    if (port >= rte_eth_dev_count() &&
-        port < (rte_eth_dev_count() + ring_if_get_count()))
+    if (port >= rte_eth_dev_count_avail() &&
+        port < (rte_eth_dev_count_avail() + ring_if_get_count()))
         return true;
 
     return false;
@@ -450,7 +435,7 @@ static int port_set_conn_options_internal(uint32_t port,
  ****************************************************************************/
 static bool port_adjust_info(uint32_t port)
 {
-    struct ether_addr mac_addr;
+    struct rte_ether_addr mac_addr;
 
     /* Adjust max_rx_pktlen. Max pktlen size may be 2 * PORT_MAX_MTU.
      */
@@ -480,10 +465,10 @@ static bool port_adjust_info(uint32_t port)
      * of the interface may not be set and returned as -1. In those cases
      * assume the interface resides on socket-id 0.
      */
-    if (port_dev_info[port].pi_dev_info.pci_dev &&
-            port_dev_info[port].pi_dev_info.pci_dev->device.numa_node != -1)
+    if (port_dev_info[port].pi_dev_info.device &&
+            port_dev_info[port].pi_dev_info.device->numa_node != -1)
         port_dev_info[port].pi_numa_node =
-            port_dev_info[port].pi_dev_info.pci_dev->device.numa_node;
+            port_dev_info[port].pi_dev_info.device->numa_node;
 
     /* Prefetch the port MAC address. */
     rte_eth_macaddr_get(port, &mac_addr);
@@ -505,7 +490,7 @@ static bool port_setup_port(uint8_t port)
 #endif /* !defined(TPG_SW_CHECKSUMMING) */
     uint16_t               number_of_rings;
     global_config_t       *cfg;
-    struct ether_addr      mac_addr;
+    struct rte_ether_addr  mac_addr;
     tpg_port_options_t     default_port_options;
     struct rte_eth_rxconf  rx_conf;
     struct rte_eth_txconf  tx_conf;
@@ -515,21 +500,26 @@ static bool port_setup_port(uint8_t port)
             .mq_mode        = ETH_MQ_RX_RSS,
             .max_rx_pkt_len = port_dev_info[port].pi_dev_info.max_rx_pktlen,
             .split_hdr_size = 0,
-            .header_split   = 0, /**< Header Split disabled */
-            .hw_ip_checksum = 1, /**< IP checksum offload enabled */
-            .hw_vlan_filter = 0, /**< VLAN filtering disabled */
-            .jumbo_frame    = 1, /**< Jumbo Frame Support enabled */
-            .hw_strip_crc   = 0, /**< CRC stripped by hardware */
-            .enable_scatter = 1,
+            .offloads       = DEV_RX_OFFLOAD_IPV4_CKSUM |
+                              DEV_RX_OFFLOAD_JUMBO_FRAME |
+                              DEV_RX_OFFLOAD_SCATTER |
+                              DEV_RX_OFFLOAD_KEEP_CRC,
         },
         .rx_adv_conf = {
             .rss_conf = {
                 .rss_key = port_rss_key,
                 .rss_key_len = sizeof(port_rss_key),
-                .rss_hf = ETH_RSS_IPV4 | ETH_RSS_NONFRAG_IPV4_TCP | ETH_RSS_NONFRAG_IPV4_UDP,
+                .rss_hf = ETH_RSS_IPV4 |
+                          ETH_RSS_NONFRAG_IPV4_TCP |
+                          ETH_RSS_NONFRAG_IPV4_UDP,
             },
         },
         .txmode = {
+#if !defined(TPG_SW_CHECKSUMMING)
+            .offloads = DEV_TX_OFFLOAD_IPV4_CKSUM |
+                        DEV_TX_OFFLOAD_UDP_CKSUM |
+                        DEV_TX_OFFLOAD_TCP_CKSUM,
+#endif
             .mq_mode = ETH_MQ_TX_NONE,
         }
     };
@@ -537,10 +527,10 @@ static bool port_setup_port(uint8_t port)
 #if defined(TPG_SW_CHECKSUMMING)
     if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_IPV4_CKSUM) !=
             DEV_RX_OFFLOAD_IPV4_CKSUM)
-        default_port_config.rxmode.hw_ip_checksum = 0;
+        default_port_config.rxmode.offloads &= ~DEV_RX_OFFLOAD_IPV4_CKSUM;
 #endif /* !defined(TPG_SW_CHECKSUMMING) */
 
-    /* Initialise configurations for rx and tx*/
+    /* Initialise configurations for rx and tx */
     port_init_rx_conf(port);
     port_init_tx_conf(port);
 
@@ -577,6 +567,18 @@ static bool port_setup_port(uint8_t port)
                        port_dev_info[port].pi_dev_info.driver_name);
 #endif /* !defined(TPG_SW_CHECKSUMMING) */
 
+    if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_JUMBO_FRAME) !=
+            DEV_RX_OFFLOAD_JUMBO_FRAME)
+        default_port_config.rxmode.offloads &= ~DEV_RX_OFFLOAD_JUMBO_FRAME;
+
+    if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_SCATTER) !=
+            DEV_RX_OFFLOAD_SCATTER)
+        default_port_config.rxmode.offloads &= ~DEV_RX_OFFLOAD_SCATTER;
+
+    if ((port_dev_info[port].pi_dev_info.rx_offload_capa & DEV_RX_OFFLOAD_KEEP_CRC) !=
+            DEV_RX_OFFLOAD_KEEP_CRC)
+        default_port_config.rxmode.offloads &= ~DEV_RX_OFFLOAD_KEEP_CRC;
+
     RTE_LOG(INFO, USER1, "[%s()] Initializing Ethernet port %u.\n", __func__,
             port);
 
@@ -593,6 +595,18 @@ static bool port_setup_port(uint8_t port)
                 port, default_port_config.rx_adv_conf.rss_conf.rss_key_len, sizeof(port_rss_key));
         return false;
     }
+
+    if ((port_dev_info[port].pi_dev_info.flow_type_rss_offloads & ETH_RSS_IPV4) !=
+            ETH_RSS_IPV4)
+        default_port_config.rx_adv_conf.rss_conf.rss_hf &= ~ETH_RSS_IPV4;
+
+    if ((port_dev_info[port].pi_dev_info.flow_type_rss_offloads & ETH_RSS_NONFRAG_IPV4_TCP) !=
+            ETH_RSS_NONFRAG_IPV4_TCP)
+        default_port_config.rx_adv_conf.rss_conf.rss_hf &= ~ETH_RSS_NONFRAG_IPV4_TCP;
+
+    if ((port_dev_info[port].pi_dev_info.flow_type_rss_offloads & ETH_RSS_NONFRAG_IPV4_UDP) !=
+            ETH_RSS_NONFRAG_IPV4_UDP)
+        default_port_config.rx_adv_conf.rss_conf.rss_hf &= ~ETH_RSS_NONFRAG_IPV4_UDP;
 
     if (number_of_rings > port_dev_info[port].pi_dev_info.max_rx_queues ||
         number_of_rings > port_dev_info[port].pi_dev_info.max_tx_queues) {
@@ -945,8 +959,8 @@ static void port_handle_cmdline_opt_qmap_maxc(uint64_t *pcore_mask)
      * In the future this should be properly taken care of by having an
      * abstraction layer to provide all the capabilities of physical AND
      * virtual interfaces. Also, we could start with the current
-     * rte_eth_dev_count() as we know RING interfaces are added starting with
-     * that value but we try not to make it even hackier..
+     * rte_eth_dev_count_avail() as we know RING interfaces are added starting
+     * with that value but we try not to make it even hackier..
      */
     for (port = 0;
          port < port_count && !port_pre_init_is_ring_port(port);
@@ -985,7 +999,7 @@ static bool port_start_ports(void)
     struct rte_eth_link link;
 
     /* First setup and start the ethernet ports. */
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if (!port_setup_port(port))
             return false;
     }
@@ -995,7 +1009,7 @@ static bool port_start_ports(void)
      * rte_eth_link_get we make sure that (at least) after init the ports have
      * finished their initialization.
      */
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         rte_eth_link_get(port, &link);
         if (!link.link_status) {
             RTE_LOG(WARNING, USER1,
@@ -1273,7 +1287,7 @@ static void cmd_show_port_statistics_parsed(void *parsed_result __rte_unused,
     struct cmd_show_port_statistics_result *pr = parsed_result;
     printer_arg_t                           parg = TPG_PRINTER_ARG(cli_printer, cl);
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 
@@ -1334,7 +1348,7 @@ static void cmd_show_port_statistics_parsed(void *parsed_result __rte_unused,
 
     if (option == 'd') {
 
-        for (port = 0; port < rte_eth_dev_count(); port++) {
+        for (port = 0; port < rte_eth_dev_count_avail(); port++) {
 
             struct rte_eth_stats estats;
 
@@ -1359,7 +1373,7 @@ static void cmd_show_port_statistics_parsed(void *parsed_result __rte_unused,
             cmdline_printf(cl, "\n");
         }
 
-        for (port = 0; port < rte_eth_dev_count(); port++) {
+        for (port = 0; port < rte_eth_dev_count_avail(); port++) {
 
 #define MAX_XSTATS_TO_DISPLAY 256
 
@@ -1482,7 +1496,7 @@ static void cmd_show_port_link_parsed(void *parsed_result __rte_unused,
 {
     int port;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         struct rte_eth_link link;
 
         port_link_info_get(port, &link);
@@ -1538,7 +1552,7 @@ static void cmd_show_port_map_parsed(void *parsed_result __rte_unused,
 {
     uint32_t port;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         uint32_t core;
 
         cmdline_printf(cl, "Port %u[socket: %d]:\n", port,
@@ -1594,7 +1608,7 @@ static void cmd_show_port_info_parsed(void *parsed_result __rte_unused,
     cmdline_printf(cl, "Port Driver           MTU   PCI address  Soc rx    tx    offload offload    IPv4   IPv6  ex  2\n");
     cmdline_printf(cl, "---- ---------------- ----- ------------ --- ----- ----- ------- ---------- ------+---------+--\n");
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
 
         struct rte_eth_dev_info  dev_info;
         struct rte_pci_device   *pci_dev = NULL;
@@ -1602,9 +1616,9 @@ static void cmd_show_port_info_parsed(void *parsed_result __rte_unused,
 
         rte_eth_dev_info_get(port, &dev_info);
 
-        if (dev_info.pci_dev) {
-            pci_dev = dev_info.pci_dev;
-            pci = &dev_info.pci_dev->addr;
+        if (dev_info.device) {
+            pci_dev = RTE_ETH_DEV_TO_PCI(&dev_info);
+            pci = &pci_dev->addr;
         }
 
         cmdline_printf(cl,
@@ -1716,7 +1730,7 @@ static cmdline_parse_ctx_t cli_ctx[] = {
  * port_interfaces_init()
  *      Intializes the port mapping memory. Creates ring interfaces if
  *      required. This function MUST be called before iterating through eth
- *      devices or using the result of rte_eth_dev_count()!
+ *      devices or using the result of rte_eth_dev_count_avail()!
  ****************************************************************************/
 static bool port_interfaces_init(void)
 {
@@ -1798,7 +1812,7 @@ static bool port_interfaces_init(void)
     /* Initialize port_info for all physical ports. Ring-if port_info is
      * initialized by ring_if_init().
      */
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         rte_eth_dev_info_get(port, &port_dev_info[port].pi_dev_info);
         if (!port_adjust_info(port))
             return false;
@@ -1809,7 +1823,7 @@ static bool port_interfaces_init(void)
      *
      *   The init functions below should be called in this order,
      *   reason being that once the init function returns it's
-     *   interface are now included in the rte_eth_dev_count()!!
+     *   interface are now included in the rte_eth_dev_count_avail()!!
      */
     if (!ring_if_init()) {
         RTE_LOG(ERR, USER1, "ERROR: Failed initializing ring interfaces!\n");
@@ -1846,16 +1860,16 @@ bool port_init(void)
      * WARNING: this must be first as we need the qmaps when initializing ring
      * interfaces. The ring interfaces MUST be initialized early as they count
      * as "eth devices" and there are a lot of arrays checking for
-     * rte_eth_dev_count().
+     * rte_eth_dev_count_avail().
      */
     if (!port_interfaces_init()) {
         RTE_LOG(ERR, USER1, "ERROR: Can't initialize interfaces!\n");
         return false;
     }
 
-    /* rte_eth_dev_count() was updated by the call to port_interfaces_init().
-     * We can deal with any ring interfaes that were created as if they were
-     * "normal" interfaces.
+    /* rte_eth_dev_count_avail() was updated by the call to
+     * port_interfaces_init(). We can deal with any ring interfaes that were
+     * created as if they were "normal" interfaces.
      */
 
     /*
@@ -1871,7 +1885,7 @@ bool port_init(void)
      * Allocate memory for link rate stats and initialize all of them.
      */
     link_rate_statistics = rte_malloc("link_rate_stats",
-                                      rte_eth_dev_count() *
+                                      rte_eth_dev_count_avail() *
                                         sizeof(*link_rate_statistics),
                                       0);
 
@@ -1881,14 +1895,14 @@ bool port_init(void)
         return false;
     }
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         bzero(&link_rate_statistics[port].lrs_estats,
               sizeof(link_rate_statistics[port].lrs_estats));
         link_rate_statistics[port].lrs_timestamp = rte_get_timer_cycles();
     }
 
     RTE_LOG(INFO, USER1, "Found %d Ethernet ports to start.\n",
-            rte_eth_dev_count());
+            rte_eth_dev_count_avail());
 
     /*
      * Initialize all available ethernet ports.
@@ -1896,7 +1910,8 @@ bool port_init(void)
     if (!port_start_ports())
         return false;
 
-    RTE_LOG(INFO, USER1, "Started %d Ethernet ports.\n", rte_eth_dev_count());
+    RTE_LOG(INFO, USER1, "Started %d Ethernet ports.\n",
+            rte_eth_dev_count_avail());
 
     return true;
 }

--- a/src/tpg_route.c
+++ b/src/tpg_route.c
@@ -186,7 +186,7 @@ static int route_intf_add_cb(uint16_t msgid, uint16_t lcore, void *msg)
         return -ENOMEM;
     }
 
-    nh_zero = TPG_IPV4(IPv4(0, 0, 0, 0));
+    nh_zero = TPG_IPV4(RTE_IPV4(0, 0, 0, 0));
     if (!route_update_entry(add_msg->rim_eth_port, &add_msg->rim_ip,
                             &add_msg->rim_mask,
                             &nh_zero,
@@ -280,7 +280,8 @@ static int route_gw_add_cb(uint16_t msgid, uint16_t lcore, void *msg)
 
     assert(PORT_CORE_DEFAULT(port) == lcore);
 
-    default_gw_per_port[port] = ROUTE_V4(IPv4(0, 0, 0, 0), IPv4(0, 0, 0, 0),
+    default_gw_per_port[port] = ROUTE_V4(RTE_IPV4(0, 0, 0, 0),
+                                         RTE_IPV4(0, 0, 0, 0),
                                          add_msg->rgm_gw.ip_v4,
                                          ROUTE_FLAG_IN_USE);
 
@@ -353,7 +354,7 @@ bool route_init(void)
      * Allocate per port routing table.
      */
     route_per_port_table = rte_zmalloc("route_tables",
-                                       rte_eth_dev_count() *
+                                       rte_eth_dev_count_avail() *
                                        TPG_ROUTE_PORT_TABLE_SIZE *
                                        sizeof(*route_per_port_table),
                                        0);
@@ -363,7 +364,7 @@ bool route_init(void)
     }
 
     gw_per_port_per_vlan = rte_zmalloc("gw_per_port_per_vlan",
-                                       rte_eth_dev_count() *
+                                       rte_eth_dev_count_avail() *
                                        TPG_GW_PORT_VLAN_SIZE *
                                        sizeof(*gw_per_port_per_vlan),
                                        0);
@@ -374,7 +375,7 @@ bool route_init(void)
     }
 
     default_gw_per_port = rte_zmalloc("default_gw_per_port",
-                                      rte_eth_dev_count() *
+                                      rte_eth_dev_count_avail() *
                                       sizeof(*default_gw_per_port),
                                       0);
     if (default_gw_per_port == NULL) {
@@ -649,7 +650,7 @@ static void cmd_show_route_statistics_parsed(void *parsed_result __rte_unused,
     struct cmd_show_route_statistics_result *pr = parsed_result;
     printer_arg_t                            parg = TPG_PRINTER_ARG(cli_printer, cl);
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 

--- a/src/tpg_tcp.c
+++ b/src/tpg_tcp.c
@@ -384,12 +384,12 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
 {
     unsigned int          tcp_hdr_len;
     tpg_tcp_statistics_t *stats;
-    struct tcp_hdr       *tcp_hdr;
+    struct rte_tcp_hdr   *tcp_hdr;
     tcp_control_block_t  *tcb;
 
     stats = STATS_LOCAL(tpg_tcp_statistics_t, pcb->pcb_port);
 
-    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct tcp_hdr))) {
+    if (unlikely(rte_pktmbuf_data_len(mbuf) < sizeof(struct rte_tcp_hdr))) {
         RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: mbuf fragment to small for tcp_hdr!\n",
                 pcb->pcb_core_index, __func__);
 
@@ -397,19 +397,19 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
         return mbuf;
     }
 
-    tcp_hdr = rte_pktmbuf_mtod(mbuf, struct tcp_hdr *);
+    tcp_hdr = rte_pktmbuf_mtod(mbuf, struct rte_tcp_hdr *);
     tcp_hdr_len = (tcp_hdr->data_off >> 4) << 2;
 
     PKT_TRACE(pcb, TCP, DEBUG, "sport=%u, dport=%u, hdrlen=%u, flags=%c%c%c%c%c%c, data_len=%u",
               rte_be_to_cpu_16(tcp_hdr->src_port),
               rte_be_to_cpu_16(tcp_hdr->dst_port),
               tcp_hdr_len,
-              (tcp_hdr->tcp_flags & TCP_URG_FLAG) == 0 ? '-' : 'u',
-              (tcp_hdr->tcp_flags & TCP_ACK_FLAG) == 0 ? '-' : 'a',
-              (tcp_hdr->tcp_flags & TCP_PSH_FLAG) == 0 ? '-' : 'p',
-              (tcp_hdr->tcp_flags & TCP_RST_FLAG) == 0 ? '-' : 'r',
-              (tcp_hdr->tcp_flags & TCP_SYN_FLAG) == 0 ? '-' : 's',
-              (tcp_hdr->tcp_flags & TCP_FIN_FLAG) == 0 ? '-' : 'f',
+              (tcp_hdr->tcp_flags & RTE_TCP_URG_FLAG) == 0 ? '-' : 'u',
+              (tcp_hdr->tcp_flags & RTE_TCP_ACK_FLAG) == 0 ? '-' : 'a',
+              (tcp_hdr->tcp_flags & RTE_TCP_PSH_FLAG) == 0 ? '-' : 'p',
+              (tcp_hdr->tcp_flags & RTE_TCP_RST_FLAG) == 0 ? '-' : 'r',
+              (tcp_hdr->tcp_flags & RTE_TCP_SYN_FLAG) == 0 ? '-' : 's',
+              (tcp_hdr->tcp_flags & RTE_TCP_FIN_FLAG) == 0 ? '-' : 'f',
               pcb->pcb_l4_len - tcp_hdr_len);
 
     PKT_TRACE(pcb, TCP, DEBUG, "  seq=%u, ack=%u, window=%u, urgent=%u",
@@ -437,7 +437,7 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
         return mbuf;
     }
 
-    if (unlikely(tcp_hdr_len < sizeof(struct tcp_hdr))) {
+    if (unlikely(tcp_hdr_len < sizeof(struct rte_tcp_hdr))) {
         RTE_LOG(DEBUG, USER2, "[%d:%s()] ERR: TCP hdr len smaller than header!\n",
                 pcb->pcb_core_index, __func__);
 
@@ -447,7 +447,7 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
 
 #ifndef _SPEEDY_PKT_PARSE_
 
-    if (unlikely((tcp_hdr->tcp_flags & ~TCP_FLAG_ALL) != 0 ||
+    if (unlikely((tcp_hdr->tcp_flags & ~0x3F) != 0 ||
                  (tcp_hdr->data_off & 0x0F) != 0)) {
         /* No log message for this, as I know Francois is misusing these bits */
         INC_STATS(stats, ts_reserved_bit_set);
@@ -461,7 +461,7 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
         RTE_SET_USED(options);
 
         for (i = 0;
-             i < ((tcp_hdr_len - sizeof(struct tcp_hdr)) / sizeof(uint32_t));
+             i < ((tcp_hdr_len - sizeof(struct rte_tcp_hdr)) / sizeof(uint32_t));
              i++) {
 
             PKT_TRACE(pcb, TCP, DEBUG, "  option word 0x%2.2X: 0x%8.8X",
@@ -549,7 +549,7 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
      * If no existing tcb see if we have a server available that is
      * accepting new requests.
      */
-    if (tcb == NULL && (tcp_hdr->tcp_flags & TCP_SYN_FLAG) != 0) {
+    if (tcb == NULL && (tcp_hdr->tcp_flags & RTE_TCP_SYN_FLAG) != 0) {
         uint32_t tcp_listen_hash;
 
         tcp_listen_hash = tlkp_calc_pkt_hash(0, /* src_addr ANY */
@@ -624,19 +624,19 @@ struct rte_mbuf *tcp_receive_pkt(packet_control_block_t *pcb,
 /*****************************************************************************
  * tcp_build_hdr()
  ****************************************************************************/
-static struct tcp_hdr *tcp_build_hdr(tcp_control_block_t *tcb,
-                                     struct rte_mbuf *mbuf,
-                                     struct ipv4_hdr *ipv4_hdr,
-                                     uint32_t sseq,
-                                     uint32_t flags)
+static struct rte_tcp_hdr *tcp_build_hdr(tcp_control_block_t *tcb,
+                                         struct rte_mbuf *mbuf,
+                                         struct rte_ipv4_hdr *ipv4_hdr,
+                                         uint32_t sseq,
+                                         uint32_t flags)
 {
-    uint16_t        tcp_hdr_len = sizeof(struct tcp_hdr);
-    uint16_t        tcp_hdr_offset = rte_pktmbuf_data_len(mbuf);
-    struct tcp_hdr *tcp_hdr;
-    uint32_t        ip_hdr_len;
+    uint16_t            tcp_hdr_len = sizeof(struct rte_tcp_hdr);
+    uint16_t            tcp_hdr_offset = rte_pktmbuf_data_len(mbuf);
+    struct rte_tcp_hdr *tcp_hdr;
+    uint32_t            ip_hdr_len;
 
     /* TODO: Support options, we need more room */
-    tcp_hdr = (struct tcp_hdr *) rte_pktmbuf_append(mbuf, tcp_hdr_len);
+    tcp_hdr = (struct rte_tcp_hdr *) rte_pktmbuf_append(mbuf, tcp_hdr_len);
 
     if (unlikely(!tcp_hdr))
         return NULL;
@@ -691,10 +691,10 @@ static struct tcp_hdr *tcp_build_hdr(tcp_control_block_t *tcb,
 static struct rte_mbuf *tcp_build_hdr_mbuf(tcp_control_block_t *tcb,
                                            uint32_t sseq, uint32_t flags,
                                            uint16_t l4_len,
-                                           struct tcp_hdr **tcp_hdr_p)
+                                           struct rte_tcp_hdr **tcp_hdr_p)
 {
     struct rte_mbuf *mbuf;
-    struct ipv4_hdr *ip_hdr;
+    struct rte_ipv4_hdr *ip_hdr;
 
     if (tcb->tcb_l4.l4cb_domain != AF_INET) {
         TPG_ERROR_ABORT("TODO: TCP = IPv4 only for now!\n");
@@ -702,7 +702,7 @@ static struct rte_mbuf *tcp_build_hdr_mbuf(tcp_control_block_t *tcb,
     }
 
     mbuf = ipv4_build_hdr_mbuf(&tcb->tcb_l4, IPPROTO_TCP,
-                               sizeof(struct tcp_hdr) + l4_len,
+                               sizeof(struct rte_tcp_hdr) + l4_len,
                                &ip_hdr);
     if (unlikely(!mbuf))
         return NULL;
@@ -728,7 +728,7 @@ static bool tcp_send_pkt(tcp_control_block_t *tcb, uint32_t sseq,
                          uint32_t data_pkt_len, uint32_t data_nb_segs)
 {
     struct rte_mbuf      *hdr;
-    struct tcp_hdr       *tcp_hdr;
+    struct rte_tcp_hdr   *tcp_hdr;
     tpg_tcp_statistics_t *stats;
 
     TCB_CHECK(tcb);
@@ -752,7 +752,7 @@ static bool tcp_send_pkt(tcp_control_block_t *tcb, uint32_t sseq,
             !tcb->tcb_l4.l4cb_sockopt.so_eth.ethso_tx_offload_tcp_cksum) {
         if ((DATA_IS_TSTAMP(data_mbuf))) {
             tstamp_write_cksum_offset(hdr,
-                                      hdr->pkt_len - sizeof(struct tcp_hdr) +
+                                      hdr->pkt_len - sizeof(struct rte_tcp_hdr) +
                                       RTE_PTR_DIFF(&tcp_hdr->cksum, tcp_hdr));
         }
     }
@@ -928,7 +928,7 @@ static void cmd_show_tcp_statistics_parsed(void *parsed_result __rte_unused,
     struct cmd_show_tcp_statistics_result *pr = parsed_result;
     printer_arg_t                          parg = TPG_PRINTER_ARG(cli_printer, cl);
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 

--- a/src/tpg_tcp_data.c
+++ b/src/tpg_tcp_data.c
@@ -222,10 +222,10 @@ int tcp_data_send(tcp_control_block_t *tcb, tsm_data_arg_t *data)
     *data->tda_data_sent = 0;
 
     if (data->tda_push)
-        snd_flags |= TCP_PSH_FLAG;
+        snd_flags |= RTE_TCP_PSH_FLAG;
 
     if (data->tda_urg)
-        snd_flags |= TCP_URG_FLAG;
+        snd_flags |= RTE_TCP_URG_FLAG;
 
     stored_bytes = tcp_data_store_send(tcb, data);
     if (stored_bytes == 0)
@@ -247,7 +247,7 @@ int tcp_data_send(tcp_control_block_t *tcb, tsm_data_arg_t *data)
 
     tcp_data_send_segments(tcb, data_to_send, unsent_size, data_offset,
                            tcb->tcb_snd.nxt,
-                           TCP_ACK_FLAG | snd_flags);
+                           RTE_TCP_ACK_FLAG | snd_flags);
 
 done:
     if (data->tda_data_len == stored_bytes) {
@@ -447,7 +447,7 @@ uint32_t tcp_data_retrans(tcp_control_block_t *tcb)
                                                    tcb->tcb_snd.wnd),
                                            0,
                                            tcb->tcb_snd.una,
-                                           TCP_ACK_FLAG);
+                                           RTE_TCP_ACK_FLAG);
     return retrans_bytes;
 }
 

--- a/src/tpg_tcp_lookup.c
+++ b/src/tpg_tcp_lookup.c
@@ -114,7 +114,7 @@ void tlkp_tcp_lcore_init(uint32_t lcore_id)
     uint32_t i;
 
     RTE_PER_LCORE(tlkp_tcb_hash_table) =
-        rte_zmalloc_socket("tcp_hash_table", rte_eth_dev_count() *
+        rte_zmalloc_socket("tcp_hash_table", rte_eth_dev_count_avail() *
                            TPG_HASH_BUCKET_SIZE *
                            sizeof(tlkp_hash_bucket_t),
                            RTE_CACHE_LINE_SIZE,
@@ -124,7 +124,8 @@ void tlkp_tcp_lcore_init(uint32_t lcore_id)
                         rte_lcore_index(lcore_id));
     }
 
-    for (i = 0; i < (uint32_t)(rte_eth_dev_count() * TPG_HASH_BUCKET_SIZE);
+    for (i = 0; i < (uint32_t)(rte_eth_dev_count_avail() *
+                               TPG_HASH_BUCKET_SIZE);
          i++) {
         /*
          * Initialize all list headers.

--- a/src/tpg_test_mgmt.c
+++ b/src/tpg_test_mgmt.c
@@ -1122,7 +1122,7 @@ static bool test_mgmt_init_env(void)
      * Allocate port test configuration array.
      */
     test_env = rte_zmalloc_socket("test_env",
-                                  rte_eth_dev_count() * sizeof(*test_env),
+                                  rte_eth_dev_count_avail() * sizeof(*test_env),
                                   0,
                                   rte_lcore_to_socket_id(rte_lcore_id()));
 
@@ -1139,7 +1139,7 @@ static bool test_mgmt_init_runtime_stats(void)
      */
     test_runtime_gen_stats =
         rte_zmalloc_socket("test_runtime_gen_stats",
-                           rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES *
+                           rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES *
                            sizeof(*test_runtime_gen_stats),
                            0,
                            rte_lcore_to_socket_id(rte_lcore_id()));
@@ -1148,7 +1148,7 @@ static bool test_mgmt_init_runtime_stats(void)
 
     test_runtime_rate_stats =
         rte_zmalloc_socket("test_runtime_rate_stats",
-                           rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES *
+                           rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES *
                            sizeof(*test_runtime_rate_stats),
                            0,
                            rte_lcore_to_socket_id(rte_lcore_id()));
@@ -1157,7 +1157,7 @@ static bool test_mgmt_init_runtime_stats(void)
 
     test_runtime_app_stats =
         rte_zmalloc_socket("test_runtime_app_stats",
-                           rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES *
+                           rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES *
                            sizeof(*test_runtime_app_stats),
                            0,
                            rte_lcore_to_socket_id(rte_lcore_id()));

--- a/src/tpg_test_mgmt_api.c
+++ b/src/tpg_test_mgmt_api.c
@@ -1871,8 +1871,10 @@ int test_mgmt_get_phy_stats(uint32_t eth_port,
     total_stats->pys_rx_bytes = phy_stats.ibytes;
     total_stats->pys_tx_pkts = phy_stats.opackets;
     total_stats->pys_tx_bytes = phy_stats.obytes;
+    total_stats->pys_rx_drops = phy_stats.imissed;
     total_stats->pys_rx_errors = phy_stats.ierrors;
     total_stats->pys_tx_errors = phy_stats.oerrors;
+    total_stats->pys_rx_nombuf = phy_stats.rx_nombuf;
     total_stats->pys_link_speed = link_info.link_speed;
 
     return 0;
@@ -1900,8 +1902,10 @@ int test_mgmt_get_phy_rate_stats(uint32_t eth_port,
     rate_stats->pys_rx_bytes = phy_stats.ibytes;
     rate_stats->pys_tx_pkts = phy_stats.opackets;
     rate_stats->pys_tx_bytes = phy_stats.obytes;
+    rate_stats->pys_rx_drops = phy_stats.imissed;
     rate_stats->pys_rx_errors = phy_stats.ierrors;
     rate_stats->pys_tx_errors = phy_stats.oerrors;
+    rate_stats->pys_rx_nombuf = phy_stats.rx_nombuf;
     rate_stats->pys_link_speed = link_info.link_speed;
 
     return 0;

--- a/src/tpg_test_mgmt_api.c
+++ b/src/tpg_test_mgmt_api.c
@@ -2111,6 +2111,13 @@ int test_mgmt_get_tcp_stats(uint32_t eth_port,
 #ifndef _SPEEDY_PKT_PARSE_
         total_stats->ts_reserved_bit_set += tcp_stats->ts_reserved_bit_set;
 #endif
+
+        total_stats->ts_recv_syn += tcp_stats->ts_recv_syn;
+        total_stats->ts_sent_syn += tcp_stats->ts_sent_syn;
+        total_stats->ts_recv_fin += tcp_stats->ts_recv_fin;
+        total_stats->ts_sent_fin += tcp_stats->ts_sent_fin;
+        total_stats->ts_recv_rst += tcp_stats->ts_recv_rst;
+        total_stats->ts_sent_rst += tcp_stats->ts_sent_rst;
     }
 
     return 0;

--- a/src/tpg_test_mgmt_api.c
+++ b/src/tpg_test_mgmt_api.c
@@ -239,7 +239,7 @@ static void test_init_sockopt_defaults(sockopt_t *sockopt,
 static bool test_mgmt_validate_port_id(uint32_t eth_port,
                                        printer_arg_t *printer_arg)
 {
-    if (eth_port >= rte_eth_dev_count()) {
+    if (eth_port >= rte_eth_dev_count_avail()) {
         tpg_printf(printer_arg, "ERROR: Invalid ethernet port!\n");
         return false;
     }

--- a/src/tpg_test_mgmt_cli.c
+++ b/src/tpg_test_mgmt_cli.c
@@ -261,7 +261,7 @@ static void cmd_show_link_rate_parsed(void *parsed_result __rte_unused,
 
     parg = TPG_PRINTER_ARG(cli_printer, cl);
 
-    for (eth_port = 0; eth_port < rte_eth_dev_count(); eth_port++)
+    for (eth_port = 0; eth_port < rte_eth_dev_count_avail(); eth_port++)
         test_show_link_rate(eth_port, &parg);
 }
 
@@ -418,9 +418,9 @@ static void cmd_show_tests_config_parsed(void *parsed_result, struct cmdline *cl
     parg = TPG_PRINTER_ARG(cli_printer, cl);
     pr = parsed_result;
 
-    if (pr->port >= rte_eth_dev_count()) {
+    if (pr->port >= rte_eth_dev_count_avail()) {
         cmdline_printf(cl, "ERROR: Port should be in the range 0..%"PRIu32"\n",
-                       rte_eth_dev_count());
+                       rte_eth_dev_count_avail());
         return;
     }
 
@@ -483,9 +483,9 @@ static void cmd_show_tests_state_parsed(void *parsed_result, struct cmdline *cl,
     parg = TPG_PRINTER_ARG(cli_printer, cl);
     pr = parsed_result;
 
-    if (pr->port >= rte_eth_dev_count()) {
+    if (pr->port >= rte_eth_dev_count_avail()) {
         cmdline_printf(cl, "ERROR: Port should be in the range 0..%"PRIu32"\n",
-                       rte_eth_dev_count());
+                       rte_eth_dev_count_avail());
         return;
     }
 
@@ -636,7 +636,7 @@ static void cmd_tests_add_l3_intf_parsed(void *parsed_result, struct cmdline *cl
     parg = TPG_PRINTER_ARG(cli_printer, cl);
     pr = parsed_result;
     vlan_enable = (intptr_t)data;
-    gw = TPG_IPV4(IPv4(0, 0, 0, 0));
+    gw = TPG_IPV4(RTE_IPV4(0, 0, 0, 0));
 
     if (pr->ip.family != AF_INET) {
         cmdline_printf(cl, "ERROR: IPv6 not supported yet!\n");

--- a/src/tpg_test_stats.c
+++ b/src/tpg_test_stats.c
@@ -777,7 +777,7 @@ static void test_display_stats_test_state(ui_win_t *ui_win,
 
     parg = TPG_PRINTER_ARG(ui_printer, ui_win->uw_win);
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         test_state_show_tcs_hdr(port, &parg);
         UI_HLINE_PRINT(ui_win->uw_win, "=", ui_win->uw_cols - 2);
 
@@ -1085,7 +1085,7 @@ static void test_display(void)
     test_display_win(&stats_test_detail_win, true,
                       test_display_stats_test_detail, NULL);
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         test_display_win(&stats_win[port], true, test_display_stats,
                          (void *)(uintptr_t)port);
     }
@@ -1199,9 +1199,9 @@ static void test_stats_init_windows(void)
      * Create the stats windows - the right part of the screen.
      */
     stats_x = stats_test_state_win.uw_cols;
-    stats_xsz = WIN_SZ(cols, STATS_WIN_XPERC) / rte_eth_dev_count();
+    stats_xsz = WIN_SZ(cols, STATS_WIN_XPERC) / rte_eth_dev_count_avail();
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         test_stats_ui_win_init(&stats_win[port],
                                lines, stats_xsz,
                                0, stats_x,
@@ -1236,7 +1236,7 @@ static void test_stats_tmr_cb(struct rte_timer *tmr __rte_unused,
 {
     uint32_t port;
 
-    for (port = 0; port < rte_eth_dev_count(); port++)
+    for (port = 0; port < rte_eth_dev_count_avail(); port++)
         test_display_win(&stats_win[port], false, test_display_stats,
                          (void *)(uintptr_t)port);
 }
@@ -1280,7 +1280,7 @@ static void test_stats_init_detail_tc(void)
 {
     uint32_t port;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if (test_mgmt_get_test_case_count(port)) {
             tpg_test_case_t entry;
 
@@ -1326,7 +1326,7 @@ static void test_stats_forward_detail_tc(void)
 
     do {
         stats_detail_port++;
-        stats_detail_port %= rte_eth_dev_count();
+        stats_detail_port %= rte_eth_dev_count_avail();
     } while (test_mgmt_get_test_case_count(stats_detail_port) == 0);
 
     for (stats_detail_tcid = 0;
@@ -1371,7 +1371,7 @@ static void test_stats_back_detail_tc(void)
 
     do {
         if (stats_detail_port == 0)
-            stats_detail_port = rte_eth_dev_count() - 1;
+            stats_detail_port = rte_eth_dev_count_avail() - 1;
         else
             stats_detail_port--;
     } while (test_mgmt_get_test_case_count(stats_detail_port) == 0);
@@ -1434,7 +1434,7 @@ void test_init_stats_screen(void)
     };
 
     stats_win = rte_zmalloc_socket("stats_win",
-                                   rte_eth_dev_count() * sizeof(*stats_win),
+                                   rte_eth_dev_count_avail() * sizeof(*stats_win),
                                    0,
                                    rte_lcore_to_socket_id(rte_lcore_id()));
 

--- a/src/tpg_tests.c
+++ b/src/tpg_tests.c
@@ -2268,7 +2268,7 @@ static void test_lcore_init_test_case_info(void)
     uint32_t eth_port;
     uint32_t tcid;
 
-    for (eth_port = 0; eth_port < rte_eth_dev_count(); eth_port++) {
+    for (eth_port = 0; eth_port < rte_eth_dev_count_avail(); eth_port++) {
         for (tcid = 0; tcid < TPG_TEST_MAX_ENTRIES; tcid++) {
             test_case_info_t *tc_info = TEST_GET_INFO(eth_port, tcid);
 
@@ -2288,48 +2288,48 @@ void test_lcore_init(uint32_t lcore_id)
 {
     test_lcore_init_pool(RTE_PER_LCORE(test_case_info),
                          "per_lcore_test_case_info",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
 
     test_lcore_init_pool(RTE_PER_LCORE(test_case_cfg),
                          "per_lcore_test_case_cfg",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
 
     test_lcore_init_pool(RTE_PER_LCORE(test_case_stats),
                          "per_lcore_test_stats",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
 
     test_lcore_init_pool(RTE_PER_LCORE(test_case_latency_state),
                          "per_lcore_test_case_latency_state",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
 
     test_lcore_init_pool(RTE_PER_LCORE(test_open_msgpool),
                          "per_lcore_open_msgpool",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
     test_lcore_init_pool(RTE_PER_LCORE(test_close_msgpool),
                          "per_lcore_close_msgpool",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
     test_lcore_init_pool(RTE_PER_LCORE(test_send_msgpool),
                          "per_lcore_send_msgpool",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
 
     test_lcore_init_pool(RTE_PER_LCORE(test_tmr_open_args),
                          "per_lcore_tmr_open_arg",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
     test_lcore_init_pool(RTE_PER_LCORE(test_tmr_close_args),
                          "per_lcore_tmr_close_arg",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
     test_lcore_init_pool(RTE_PER_LCORE(test_tmr_send_args),
                          "per_lcore_tmr_send_arg",
-                         rte_eth_dev_count() * TPG_TEST_MAX_ENTRIES,
+                         rte_eth_dev_count_avail() * TPG_TEST_MAX_ENTRIES,
                          lcore_id);
 
     test_lcore_init_test_case_info();

--- a/src/tpg_timer.c
+++ b/src/tpg_timer.c
@@ -766,7 +766,7 @@ static void cmd_show_timer_statistics_parsed(void *parsed_result __rte_unused,
     printer_arg_t                            parg = TPG_PRINTER_ARG(cli_printer, cl);
     struct cmd_show_timer_statistics_result *pr = parsed_result;
 
-    for (port = 0; port < rte_eth_dev_count(); port++) {
+    for (port = 0; port < rte_eth_dev_count_avail(); port++) {
         if ((option == 'p' || option == 'c') && port != pr->port)
             continue;
 

--- a/src/tpg_udp_lookup.c
+++ b/src/tpg_udp_lookup.c
@@ -112,7 +112,7 @@ void tlkp_udp_lcore_init(uint32_t lcore_id)
     uint32_t i;
 
     RTE_PER_LCORE(tlkp_ucb_hash_table) =
-        rte_zmalloc_socket("udp_hash_table", rte_eth_dev_count() *
+        rte_zmalloc_socket("udp_hash_table", rte_eth_dev_count_avail() *
                            TPG_HASH_BUCKET_SIZE *
                            sizeof(tlkp_hash_bucket_t),
                            RTE_CACHE_LINE_SIZE,
@@ -122,7 +122,7 @@ void tlkp_udp_lcore_init(uint32_t lcore_id)
                         rte_lcore_index(lcore_id));
     }
 
-    for (i = 0; i < (uint32_t)(rte_eth_dev_count() * TPG_HASH_BUCKET_SIZE); i++) {
+    for (i = 0; i < (uint32_t)(rte_eth_dev_count_avail() * TPG_HASH_BUCKET_SIZE); i++) {
         /*
          * Initialize all list headers.
          */

--- a/ut/test_api.py
+++ b/ut/test_api.py
@@ -570,6 +570,9 @@ class TestApi(Warp17UnitTestCase):
                     self.assertGreater(server_result.sr_tcp.ts_sent_ctrl_bytes,
                                        0,
                                        'TCP ts_sent_ctrl_bytes has to be greater than 0')
+                    self.assertGreater(server_result.sr_tcp.ts_sent_syn,
+                                       0,
+                                       'TCP ts_sent_syn has to be greater than 0')
                     self.assertGreater(server_result.sr_tcp.ts_sent_data_pkts,
                                        0,
                                        'TCP ts_sent_data_pkts has to be greater than 0')


### PR DESCRIPTION
This is a huge change that breaks backwards compatibility with any prior version of DPDK. I don't expect this to be merged but wanted to make sure the effort is visible if any wants to try it out. I'm currently testing with WARP17 and DPDK 19.11.1 over a Broadcom 100Gb NIC.