### PR TITLE
[WIP]: Don't use internal rte_ethdev_driver.h header.

### DIFF
--- a/inc/tcp_generator.h
+++ b/inc/tcp_generator.h
@@ -67,7 +67,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <rte_ethdev_driver.h>
+#include <rte_ethdev.h>
 #include <rte_timer.h>
 #include <rte_ip.h>
 #include <rte_tcp.h>


### PR DESCRIPTION
Signed-off-by: Dumitru Ceara <dceara@redhat.com>